### PR TITLE
Support implicit casts for range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,8 @@ _TeamCity*
 # NCrunch
 _NCrunch_*
 .*crunch*.local.xml
+*.ncrunchsolution
+*.ncrunchproject
 
 # MightyMoose
 *.mm.*

--- a/src/Range/Generic/Range`1.cs
+++ b/src/Range/Generic/Range`1.cs
@@ -18,5 +18,26 @@
 
         public bool IsMinInclusive { get; set; }
         public bool IsMaxInclusive { get; set; }
+
+        // User-defined conversion from Digit to double 
+        public static implicit operator string(Range<T> range)
+        {
+            return range.ToString();
+        }
+        //  User-defined conversion from double to Digit 
+        public static implicit operator Range<T>(string range)
+        {
+            return Range.FromString<T>(range) as Range<T>;
+        }
+
+        public override string ToString()
+        {
+            return string.Format("{0}{1},{2}{3}",
+                    IsMinInclusive ? "[" : "(",
+                    MinValue,
+                    MaxValue,
+                    IsMaxInclusive ? "]" : ")"
+                );
+        }
     }
 }

--- a/src/Range/Generic/Range`1.cs
+++ b/src/Range/Generic/Range`1.cs
@@ -19,12 +19,11 @@
         public bool IsMinInclusive { get; set; }
         public bool IsMaxInclusive { get; set; }
 
-        // User-defined conversion from Digit to double 
         public static implicit operator string(Range<T> range)
         {
             return range.ToString();
         }
-        //  User-defined conversion from double to Digit 
+
         public static implicit operator Range<T>(string range)
         {
             return Range.FromString<T>(range) as Range<T>;

--- a/tests/Range.Tests/RangeTests.cs
+++ b/tests/Range.Tests/RangeTests.cs
@@ -81,6 +81,27 @@ namespace RimDev.Filter.Range.Tests
                     "parsed maximum value `abc` does not match expected type of `Int32`.",
                     exception.Message);
             }
+
+            [Fact]
+            public void Implicitly_cast_from_string_to_range()
+            {
+                Range<int> range = "[1,5]";
+
+                Assert.NotNull(range);
+                Assert.Equal(1, range.MinValue);
+                Assert.Equal(true, range.IsMinInclusive);
+                Assert.Equal(true, range.IsMaxInclusive);
+                Assert.Equal(5, range.MaxValue);
+            }
+
+            [Fact]
+            public void Implicitly_cast_from_range_to_string()
+            {
+                var range = Range.FromString<int>("[1,5]") as Range<int>;
+                string value = range;
+
+                Assert.Equal("[1,5]", value);
+            }
         }
     }
 }

--- a/tests/Range.Tests/RangeTests.cs
+++ b/tests/Range.Tests/RangeTests.cs
@@ -102,6 +102,18 @@ namespace RimDev.Filter.Range.Tests
 
                 Assert.Equal("[1,5]", value);
             }
+
+            [Fact]
+            public void Directly_cast_from_a_string()
+            {
+                var range = (Range<int>)"[1,5]";
+
+                Assert.NotNull(range);
+                Assert.Equal(1, range.MinValue);
+                Assert.Equal(true, range.IsMinInclusive);
+                Assert.Equal(true, range.IsMaxInclusive);
+                Assert.Equal(5, range.MaxValue);
+            }
         }
     }
 }


### PR DESCRIPTION
Implicit casting allows users to specify and set strings directly
in code. This makes the code less verbose, and can handle more
interesting scenarios.

All of these are supported.

```csharp
Range<int> range = "[1,5]";

var range = Range.FromString<int>("[1,5]") as Range<int>;
string value = range;

var range = (Range<int>)"[1,5]";
```

![](http://media2.giphy.com/media/ejK2NEJQFG9fW/giphy.gif)