### PR TITLE
Fix issue where empty collections on the filter would filter everything

### DIFF
--- a/src/Filter/Generic/IEnumerable`1Extensions.cs
+++ b/src/Filter/Generic/IEnumerable`1Extensions.cs
@@ -123,18 +123,32 @@ namespace RimDev.Filter.Generic
             string property,
             IEnumerable values)
         {
-            var parameterExpression = Expression.Parameter(typeof(T), "x");
-            var propertyExpression = Expression.Property(parameterExpression, property);
-            var constantExpression = Expression.Constant(values);
-            var callExpression = Expression.Call(
-                typeof(Enumerable),
-                "Contains",
-                new[] { propertyExpression.Type },
-                constantExpression,
-                propertyExpression);
-            var lambda = Expression.Lambda<Func<T, bool>>(callExpression, parameterExpression);
+            var valuesCount = 0;
 
-            return query.Where(lambda);
+            foreach (var value in values)
+            {
+                valuesCount++;
+            }
+
+            if (valuesCount == 0)
+            {
+                return query;
+            }
+            else
+            {
+                var parameterExpression = Expression.Parameter(typeof(T), "x");
+                var propertyExpression = Expression.Property(parameterExpression, property);
+                var constantExpression = Expression.Constant(values);
+                var callExpression = Expression.Call(
+                    typeof(Enumerable),
+                    "Contains",
+                    new[] { propertyExpression.Type },
+                    constantExpression,
+                    propertyExpression);
+                var lambda = Expression.Lambda<Func<T, bool>>(callExpression, parameterExpression);
+
+                return query.Where(lambda);
+            }
         }
 
         private static IQueryable<T> Where<T>(

--- a/tests/Filter.Tests/Generic/IEnumerable`1ExtensionsTests.cs
+++ b/tests/Filter.Tests/Generic/IEnumerable`1ExtensionsTests.cs
@@ -68,6 +68,18 @@ namespace RimDev.Filter.Tests.Generic
             public class EnumerableFilters : Filter
             {
                 [Fact]
+                public void Should_bypass_filter_when_empty_collection()
+                {
+                    var @return = people.Filter(new
+                    {
+                        FirstName = new string[] { }
+                    });
+
+                    Assert.NotNull(@return);
+                    Assert.Equal(2, @return.Count());
+                }
+
+                [Fact]
                 public void Should_filter_when_property_types_match_as_enumerable_string()
                 {
                     var @return = people.Filter(new


### PR DESCRIPTION
Expected behavior is to treat empty collections on the filter as faux-null so effectively returning the filterable collection as-is.

References #11.