### PR TITLE
Fix filter to allow nullable filter type (non-collection)

### DIFF
--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>4</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Filter/Generic/IEnumerable`1Extensions.cs
+++ b/src/Filter/Generic/IEnumerable`1Extensions.cs
@@ -111,7 +111,15 @@ namespace RimDev.Filter.Generic
                         {
                             try
                             {
-                                queryableValue = queryableValue.Where(validValuePropertyName, filterPropertyValue);
+                                if (validValueProperty.PropertyType.IsGenericType &&
+                                    validValueProperty.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
+                                {
+                                    queryableValue = queryableValue.Where(validValuePropertyName, filterPropertyValue as Nullable);
+                                }
+                                else
+                                {
+                                    queryableValue = queryableValue.Where(validValuePropertyName, filterPropertyValue);
+                                }
                             }
                             catch (Exception)
                             { }
@@ -136,7 +144,7 @@ namespace RimDev.Filter.Generic
             var parameterExpression = Expression.Parameter(typeof(T), "x");
             var propertyExpression = (Expression)Expression.Property(parameterExpression, property);
             var constantExpression = Expression.Constant(values);
-            var propertyExpressionIsNullable =  propertyExpression.Type.IsGenericType 
+            var propertyExpressionIsNullable =  propertyExpression.Type.IsGenericType
                                                 && propertyExpression.Type.GetGenericTypeDefinition() == typeof (Nullable<>)
                                                 && constantExpression.Type.GetElementType() != propertyExpression.Type;
 

--- a/tests/Filter.Tests/App.config
+++ b/tests/Filter.Tests/App.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  </configSections>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+    </providers>
+  </entityFramework>
+</configuration>

--- a/tests/Filter.Tests/Filter.Tests.csproj
+++ b/tests/Filter.Tests/Filter.Tests.csproj
@@ -34,7 +34,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="RimDev.Automation.Sql, Version=0.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\RimDev.Automation.Sql.0.2.0\lib\net45\RimDev.Automation.Sql.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -55,8 +68,10 @@
     <Compile Include="FilterTests.cs" />
     <Compile Include="Generic\IEnumerable`1ExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Generic\Integration\EfTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Filter.Tests/Generic/IEnumerable`1ExtensionsTests.cs
+++ b/tests/Filter.Tests/Generic/IEnumerable`1ExtensionsTests.cs
@@ -161,11 +161,22 @@ namespace RimDev.Filter.Tests.Generic
             }
 
             [Fact]
-            public void Should_be_able_to_handle_nullable_destination_and_nullable_primitive_filter()
+            public void Should_be_able_to_handle_nullable_destination_and_nullable_primitive_filter_as_collection()
             {
                 var @return = People.Filter(new
                 {
                     Rating = new decimal?[] { 4.5m }
+                });
+
+                Assert.Equal(1, @return.Count());
+            }
+
+            [Fact]
+            public void Should_be_able_to_handle_nullable_destination_and_nullable_primitive_filter()
+            {
+                var @return = People.Filter(new
+                {
+                    Rating = new decimal?(4.5m)
                 });
 
                 Assert.Equal(1, @return.Count());

--- a/tests/Filter.Tests/Generic/Integration/EfTests.cs
+++ b/tests/Filter.Tests/Generic/Integration/EfTests.cs
@@ -1,0 +1,79 @@
+﻿using RimDev.Automation.Sql;
+using RimDev.Filter.Generic;
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using Xunit;
+
+namespace RimDev.Filter.Tests.Generic.Integration
+{
+    public class EfTests
+    {
+        private readonly IEnumerable<Person> People = new List<Person>()
+        {
+            new Person()
+            {
+                FavoriteDate = DateTime.Parse("2000-01-01"),
+                FavoriteLetter = 'a',
+                FavoriteNumber = 5,
+                FirstName = "John",
+                LastName = "Doe"
+            },
+            new Person()
+            {
+                FavoriteDate = DateTime.Parse("2000-01-02"),
+                FavoriteLetter = 'b',
+                FavoriteNumber = 10,
+                FirstName = "Tim",
+                LastName = "Smith",
+                Rating = 4.5m
+            },
+        };
+
+        [Fact]
+        public void Can_filter_nullable_models_via_entity_framework()
+        {
+            Database.SetInitializer(new DropCreateDatabaseAlways<FilterDbContext>());
+
+            using (var database = new LocalDb())
+            {
+                using (var context = new FilterDbContext(database.ConnectionString))
+                {
+                    context.People.AddRange(People);
+                    context.SaveChanges();
+
+                    var @return = People.Filter(new
+                    {
+                        Rating = new decimal?(4.5m)
+                    });
+
+                    Assert.Equal(1, @return.Count());
+                }
+            }
+        }
+
+        public class FilterDbContext : DbContext
+        {
+            public FilterDbContext(string nameOrConnectionString)
+                : base(nameOrConnectionString)
+            { }
+
+            public DbSet<Person> People
+            {
+                get; set;
+            }
+        }
+
+        public class Person
+        {
+            public int Id { get; set; }
+            public DateTime FavoriteDate { get; set; }
+            public char FavoriteLetter { get; set; }
+            public int FavoriteNumber { get; set; }
+            public string FirstName { get; set; }
+            public string LastName { get; set; }
+            public decimal? Rating { get; set; }
+        }
+    }
+}

--- a/tests/Filter.Tests/packages.config
+++ b/tests/Filter.Tests/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
+  <package id="RimDev.Automation.Sql" version="0.2.0" targetFramework="net45" />
   <package id="xunit" version="2.0.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.0.0" targetFramework="net45" />


### PR DESCRIPTION
Previous behavior would throw an exception due to the inability of coercing filter constant-type to a nullable target-type.
Also add tests to confirm new logic works with EF.