### PR TITLE
Optimization for filtering on collections with only one item

### DIFF
--- a/tests/Filter.Tests/Extensions/LazyExtensions.cs
+++ b/tests/Filter.Tests/Extensions/LazyExtensions.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace RimDev.Filter.Tests.Extensions
+{
+    internal static class LazyExtensions
+    {
+        public static void Dispose<T>(this Lazy<T> lazyDisposable) where T : IDisposable
+        {
+            if (lazyDisposable != null && lazyDisposable.IsValueCreated)
+            {
+                lazyDisposable.Value.Dispose();
+            }
+        }
+    }
+}

--- a/tests/Filter.Tests/Filter.Tests.csproj
+++ b/tests/Filter.Tests/Filter.Tests.csproj
@@ -65,7 +65,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\LazyExtensions.cs" />
     <Compile Include="FilterTests.cs" />
+    <Compile Include="Generic\Integration\DatabaseFixture.cs" />
     <Compile Include="Generic\IQueryable`1ExtensionsTests.cs" />
     <Compile Include="Generic\IEnumerable`1ExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/tests/Filter.Tests/Generic/Integration/DatabaseFixture.cs
+++ b/tests/Filter.Tests/Generic/Integration/DatabaseFixture.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading;
+using RimDev.Automation.Sql;
+using RimDev.Filter.Tests.Extensions;
+
+namespace RimDev.Filter.Tests.Generic.Integration
+{
+    public sealed class DatabaseFixture : IDisposable
+    {
+        private readonly Lazy<LocalDb> lazyDatabase;
+
+        public DatabaseFixture()
+        {
+            lazyDatabase = new Lazy<LocalDb>(
+                () => new LocalDb(), LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+
+        public string ConnectionString => lazyDatabase.Value.ConnectionString;
+        
+        public void Dispose()
+        {
+            lazyDatabase.Dispose();
+        }
+    }
+}

--- a/tests/Filter.Tests/Generic/Integration/EfTests.cs
+++ b/tests/Filter.Tests/Generic/Integration/EfTests.cs
@@ -80,6 +80,102 @@ namespace RimDev.Filter.Tests.Generic.Integration
             }
         }
 
+        [Fact]
+        public void Should_not_optimize_arrays_containing_multiple_values()
+        {
+            var singleParameter = new
+            {
+                FirstName = "Tim"
+            };
+
+            var collectionParameter = new
+            {
+                FirstName = new[] { "Tim", "John" }
+            };
+
+            using (var context = new FilterDbContext(fixture.ConnectionString))
+            {
+                IQueryable<Person> query = context.People.AsNoTracking();
+
+                var expectedQuery = query.Filter(singleParameter);
+                var actualQuery = query.Filter(collectionParameter);
+
+                Assert.NotEqual(expectedQuery.ToString(), actualQuery.ToString(), StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        [Fact]
+        public void Should_optimize_arrays_containing_a_single_value()
+        {
+            var singleParameter = new
+            {
+                FirstName = "Tim"
+            };
+
+            var collectionParameter = new
+            {
+                FirstName = new[] { "Tim" }
+            };
+
+            using (var context = new FilterDbContext(fixture.ConnectionString))
+            {
+                IQueryable<Person> query = context.People.AsNoTracking();
+
+                var expectedQuery = query.Filter(singleParameter);
+                var actualQuery = query.Filter(collectionParameter);
+
+                Assert.Equal(expectedQuery.ToString(), actualQuery.ToString(), StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        [Fact]
+        public void Should_not_optimize_collections_containing_multiple_values()
+        {
+            var singleParameter = new
+            {
+                FirstName = "Tim"
+            };
+
+            var collectionParameter = new
+            {
+                FirstName = new List<string> { "Tim", "John" }
+            };
+
+            using (var context = new FilterDbContext(fixture.ConnectionString))
+            {
+                IQueryable<Person> query = context.People.AsNoTracking();
+
+                var expectedQuery = query.Filter(singleParameter);
+                var actualQuery = query.Filter(collectionParameter);
+
+                Assert.NotEqual(expectedQuery.ToString(), actualQuery.ToString(), StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        [Fact]
+        public void Should_optimize_collections_containing_a_single_value()
+        {
+            var singleParameter = new
+            {
+                FirstName = "Tim"
+            };
+
+            var collectionParameter = new
+            {
+                FirstName = new List<string> { "Tim" }
+            };
+
+            using (var context = new FilterDbContext(fixture.ConnectionString))
+            {
+                IQueryable<Person> query = context.People.AsNoTracking();
+
+                var expectedQuery = query.Filter(singleParameter);
+                var actualQuery = query.Filter(collectionParameter);
+
+                Assert.Equal(expectedQuery.ToString(), actualQuery.ToString(), StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
         public sealed class FilterDbContext : DbContext
         {
             public FilterDbContext(string nameOrConnectionString)


### PR DESCRIPTION
Currently, when filtering an Entity Framework `IQueryable`, Filter will generate an `IN` clause for properties that are of type `IEnumerable`. While necessary for collections containing multiple items, this is less than ideal because Entity Framework does not parameterize `IN` clauses.

This PR introduces logic to detect if the `IEnumerable` property implements `ICollection` and contains exactly one element. If so, Filter will extract the single value and filter on that instead of the entire collection.