### PR TITLE
Parameterize SQL queries

### DIFF
--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>5</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/Filter.Tests/Generic/Integration/EfTests.cs
+++ b/tests/Filter.Tests/Generic/Integration/EfTests.cs
@@ -1,9 +1,9 @@
-using RimDev.Filter.Generic;
-using RimDev.Filter.Range.Generic;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
 using System.Linq;
+using RimDev.Filter.Generic;
+using RimDev.Filter.Range.Generic;
 using Xunit;
 
 namespace RimDev.Filter.Tests.Generic.Integration
@@ -121,7 +121,7 @@ namespace RimDev.Filter.Tests.Generic.Integration
             {
                 IQueryable<Person> query = context.People.AsNoTracking();
 
-                var expectedQuery = query.Filter(singleParameter);
+                var expectedQuery = query.Where(x => x.FirstName == singleParameter.FirstName);
                 var actualQuery = query.Filter(collectionParameter);
 
                 Assert.Equal(expectedQuery.ToString(), actualQuery.ToString(), StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
The changes introduced in #27 successfully convert `IN` clauses to equal clauses when filtering on a collection property containing only one element. However, because the value is being passed into the query as a `ConstantExpression`, Entity Framework does not generate parameterized SQL. 

This PR corrects that behavior by first wrapping the value in a class and using a `MemberExpression` instead of a `ConstantExpression` for comparison.

More details can be found in [this blog post](http://graemehill.ca/entity-framework-dynamic-queries-and-parameterization/) by @graeme-hill.