### PR TITLE
Add NEST extension

### DIFF
--- a/Filter.sln
+++ b/Filter.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{D26BB0C9-295E-4F30-90FA-532CAFA73A7D}"
 EndProject
@@ -18,6 +18,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Range.Web.Http", "samples\Range.Web.Http\Range.Web.Http.csproj", "{1EC8770C-D078-45CA-B9CA-44FE3C66136D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Range.Web.Http", "src\Range.Web.Http\Range.Web.Http.csproj", "{494EB0E9-22AD-4840-9D7C-3C8D4AB36291}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Filter.Nest", "src\Filter.Nest\Filter.Nest.csproj", "{39AC08C4-A82D-45F7-BBF2-F239028E6D85}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Filter.Nest.Tests", "tests\Filter.Nest.Tests\Filter.Nest.Tests.csproj", "{2B4310E6-CD36-4BF7-9519-6CB6A7C8F2EA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -49,6 +53,14 @@ Global
 		{494EB0E9-22AD-4840-9D7C-3C8D4AB36291}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{494EB0E9-22AD-4840-9D7C-3C8D4AB36291}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{494EB0E9-22AD-4840-9D7C-3C8D4AB36291}.Release|Any CPU.Build.0 = Release|Any CPU
+		{39AC08C4-A82D-45F7-BBF2-F239028E6D85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{39AC08C4-A82D-45F7-BBF2-F239028E6D85}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{39AC08C4-A82D-45F7-BBF2-F239028E6D85}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{39AC08C4-A82D-45F7-BBF2-F239028E6D85}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B4310E6-CD36-4BF7-9519-6CB6A7C8F2EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B4310E6-CD36-4BF7-9519-6CB6A7C8F2EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B4310E6-CD36-4BF7-9519-6CB6A7C8F2EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B4310E6-CD36-4BF7-9519-6CB6A7C8F2EA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -57,5 +69,6 @@ Global
 		{3A86B628-26DC-4E27-B688-7ED3DCA21EEB} = {D26BB0C9-295E-4F30-90FA-532CAFA73A7D}
 		{A5283D85-C24D-467A-8B29-315320E5F80F} = {D26BB0C9-295E-4F30-90FA-532CAFA73A7D}
 		{1EC8770C-D078-45CA-B9CA-44FE3C66136D} = {86DCF3A9-55B1-48EB-B5E7-EF257718DA7D}
+		{2B4310E6-CD36-4BF7-9519-6CB6A7C8F2EA} = {D26BB0C9-295E-4F30-90FA-532CAFA73A7D}
 	EndGlobalSection
 EndGlobal

--- a/src/Filter.Nest/Filter.Nest.csproj
+++ b/src/Filter.Nest/Filter.Nest.csproj
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{39AC08C4-A82D-45F7-BBF2-F239028E6D85}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>RimDev.Filter.Nest</RootNamespace>
+    <AssemblyName>RimDev.Filter.Nest</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Elasticsearch.Net, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Elasticsearch.Net.2.4.5\lib\net45\Elasticsearch.Net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NEST.2.4.5\lib\net45\Nest.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MappingAliasAttribute.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SearchDescriptorExtensions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Filter.Nest/Generic/SearchDescriptor`1Extensions.cs
+++ b/src/Filter.Nest/Generic/SearchDescriptor`1Extensions.cs
@@ -1,0 +1,16 @@
+﻿using Nest;
+
+namespace Filter.Elasticsearch.Generic
+{
+    public static class SearchDescriptor_1Extensions
+    {
+        public static SearchDescriptor<T> Filter<T>(
+            this SearchDescriptor<T> value,
+            object filter)
+            where T : class
+        {
+            value.
+            return value;
+        }
+    }
+}

--- a/src/Filter.Nest/MappingAliasAttribute.cs
+++ b/src/Filter.Nest/MappingAliasAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace RimDev.Filter.Nest
+{
+    public class MappingAliasAttribute : Attribute
+    {
+        public MappingAliasAttribute(string alias)
+        {
+            if (string.IsNullOrEmpty(alias))
+            {
+                throw new ArgumentNullException(nameof(alias));
+            }
+
+            Alias = alias;
+        }
+
+        public string Alias { get; private set; }
+    }
+}

--- a/src/Filter.Nest/Properties/AssemblyInfo.cs
+++ b/src/Filter.Nest/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Filter.Elasticsearch")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Filter.Elasticsearch")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("39ac08c4-a82d-45f7-bbf2-f239028e6d85")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Filter.Nest/SearchDescriptorExtensions.cs
+++ b/src/Filter.Nest/SearchDescriptorExtensions.cs
@@ -1,0 +1,84 @@
+﻿using Nest;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace RimDev.Filter.Nest
+{
+    public static class SearchDescriptorExtensions
+    {
+        public static SearchDescriptor<T> PostFilter<T>(
+            this SearchDescriptor<T> value,
+            object filter)
+            where T : class
+        {
+            if (filter == null)
+            {
+                return value;
+            }
+            var validValueProperties = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(x => x.CanRead)
+                .ToDictionary(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase);
+
+            var filterProperties = filter
+                .GetType()
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(x => x.CanRead);
+
+            var mustQueries = new List<Func<QueryContainerDescriptor<T>, QueryContainer>>();
+
+            foreach (var filterProperty in filterProperties)
+            {
+                PropertyInfo validValueProperty;
+                validValueProperties.TryGetValue(filterProperty.Name, out validValueProperty);
+
+                var filterPropertyValue = filterProperty.GetValue(filter, null);
+
+                if (validValueProperty != null && filterPropertyValue != null)
+                {
+                    var queries = new List<Func<QueryContainerDescriptor<T>, QueryContainer>>();
+                    var aliasAttribute = validValueProperty.GetCustomAttribute<MappingAliasAttribute>();
+                    var validValuePropertyName = aliasAttribute != null
+                        ? aliasAttribute.Alias
+                        : filterProperty.Name;
+
+                    if (typeof(IEnumerable).IsAssignableFrom(filterProperty.PropertyType)
+                        && filterProperty.PropertyType != typeof(string))
+                    {
+                        foreach (var item in (IEnumerable)filterPropertyValue)
+                        {
+                            queries.Add(x =>
+                                x.Match(y =>
+                                    y
+                                    .Field(validValuePropertyName)
+                                    .Query(item.ToString())));
+                        }
+                    }
+                    else
+                    {
+                        mustQueries.Add(x =>
+                            x.Match(y =>
+                                y
+                                .Field(validValuePropertyName)
+                                .Query(filterPropertyValue.ToString())));
+                    }
+
+                    mustQueries.Add(x =>
+                        x.Bool(y =>
+                            y.Should(queries)));
+                }
+            }
+
+            if (mustQueries.Any())
+            {
+                value = value.PostFilter(x =>
+                    x.Bool(y =>
+                        y.Must(mustQueries)));
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/Filter.Nest/packages.config
+++ b/src/Filter.Nest/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Elasticsearch.Net" version="2.4.5" targetFramework="net45" />
+  <package id="NEST" version="2.4.5" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+</packages>

--- a/tests/Filter.Nest.Tests/Filter.Nest.Tests.csproj
+++ b/tests/Filter.Nest.Tests/Filter.Nest.Tests.csproj
@@ -1,0 +1,106 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{2B4310E6-CD36-4BF7-9519-6CB6A7C8F2EA}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Filter.Nest.Tests</RootNamespace>
+    <AssemblyName>Filter.Nest.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Elasticsearch.Net, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Elasticsearch.Net.2.4.5\lib\net46\Elasticsearch.Net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ElasticsearchInside, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\elasticsearch-inside.2.3.5\lib\net451\ElasticsearchInside.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NEST.2.4.5\lib\net46\Nest.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MappingAliasAttributeTests.cs" />
+    <Compile Include="SearchDescriptorExtensionsTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Filter.Nest\Filter.Nest.csproj">
+      <Project>{39ac08c4-a82d-45f7-bbf2-f239028e6d85}</Project>
+      <Name>Filter.Nest</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/Filter.Nest.Tests/MappingAliasAttributeTests.cs
+++ b/tests/Filter.Nest.Tests/MappingAliasAttributeTests.cs
@@ -1,0 +1,39 @@
+﻿using RimDev.Filter.Nest;
+using System;
+using Xunit;
+
+namespace Filter.Nest.Tests
+{
+    public class MappingAliasAttributeTests
+    {
+        public class Constructor : MappingAliasAttributeTests
+        {
+            [Theory,
+                InlineData("valid", false),
+                InlineData("", true),
+                InlineData(null, true)]
+            public void Cannot_pass_null(string alias, bool shouldThrow)
+            {
+                if (shouldThrow)
+                {
+                    Assert.Throws<ArgumentNullException>(() => new MappingAliasAttribute(alias));
+                }
+                else
+                {
+                    new MappingAliasAttribute(alias);
+                }
+            }
+        }
+
+        public class Alias : MappingAliasAttributeTests
+        {
+            [Fact]
+            public void Can_get_alias_assigned_from_constructor()
+            {
+                var mappingAlias = new MappingAliasAttribute("valid");
+
+                Assert.Equal("valid", mappingAlias.Alias);
+            }
+        }
+    }
+}

--- a/tests/Filter.Nest.Tests/Properties/AssemblyInfo.cs
+++ b/tests/Filter.Nest.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Filter.Nest.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Filter.Nest.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("2b4310e6-cd36-4bf7-9519-6cb6a7c8f2ea")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/Filter.Nest.Tests/SearchDescriptorExtensionsTests.cs
+++ b/tests/Filter.Nest.Tests/SearchDescriptorExtensionsTests.cs
@@ -1,0 +1,112 @@
+﻿using Nest;
+using RimDev.Filter.Nest;
+using System.Linq;
+using Xunit;
+
+namespace Filter.Nest.Tests
+{
+    public class SearchDescriptorExtensionsTests
+    {
+        public class PostFilter : SearchDescriptorExtensionsTests
+        {
+            [Fact]
+            public void Can_query_using_collection()
+            {
+                using (var elasticsearch = new ElasticsearchInside.Elasticsearch())
+                {
+                    var elasticClient = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
+
+                    var camaro = new Car { Name = "Camaro" };
+                    var corvette = new Car { Name = "Corvette" };
+                    var monteCarlo = new Car { Name = "Monte Carlo" };
+
+                    elasticClient.Index(camaro, x => x.Index("vehicles"));
+                    elasticClient.Index(corvette, x => x.Index("vehicles"));
+                    elasticClient.Index(monteCarlo, x => x.Index("vehicles"));
+
+                    elasticClient.Refresh("vehicles");
+
+                    var results = elasticClient
+                        .Search<Car>(x => x.Index("vehicles")
+                        .PostFilter(new { Name = new[] { "camaro", "monte carlo" } }));
+
+                    Assert.NotNull(results);
+                    Assert.Equal(2, results.Hits.Count());
+                    Assert.Equal("Camaro", results.Hits.First().Source.Name);
+                    Assert.Equal("Monte Carlo", results.Hits.Last().Source.Name);
+                }
+            }
+
+            [Fact]
+            public void Can_query_using_single_value()
+            {
+                using (var elasticsearch = new ElasticsearchInside.Elasticsearch())
+                {
+                    var elasticClient = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
+
+                    var camaro = new Car { Name = "Camaro" };
+                    var corvette = new Car { Name = "Corvette" };
+                    var monteCarlo = new Car { Name = "Monte Carlo" };
+
+                    elasticClient.Index(camaro, x => x.Index("vehicles"));
+                    elasticClient.Index(corvette, x => x.Index("vehicles"));
+                    elasticClient.Index(monteCarlo, x => x.Index("vehicles"));
+
+                    elasticClient.Refresh("vehicles");
+
+                    var results = elasticClient
+                        .Search<Car>(x => x.Index("vehicles")
+                        .PostFilter(new { Name = "camaro" }));
+
+                    Assert.NotNull(results);
+                    Assert.Equal(1, results.Hits.Count());
+                    Assert.Equal("Camaro", results.Hits.First().Source.Name);
+                }
+            }
+
+            [Fact]
+            public void Multiple_filter_properties_queried_as_collection_of_and_operators()
+            {
+                using (var elasticsearch = new ElasticsearchInside.Elasticsearch())
+                {
+                    var elasticClient = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
+
+                    var camaro = new Car { Name = "Camaro", Year = 2000 };
+                    var corvette = new Car { Name = "Corvette", Year = 2016 };
+                    var monteCarlo = new Car { Name = "Monte Carlo", Year = 2000 };
+
+                    elasticClient.Index(camaro, x => x.Index("vehicles"));
+                    elasticClient.Index(corvette, x => x.Index("vehicles"));
+                    elasticClient.Index(monteCarlo, x => x.Index("vehicles"));
+
+                    elasticClient.Refresh("vehicles");
+
+                    var noResults = elasticClient
+                        .Search<Car>(x => x.Index("vehicles")
+                        .PostFilter(new { Name = new[] { "camaro", "monte carlo" }, Year = 2016 }));
+
+                    Assert.NotNull(noResults);
+                    Assert.Equal(0, noResults.Hits.Count());
+
+                    var twoResults = elasticClient
+                        .Search<Car>(x => x.Index("vehicles")
+                        .PostFilter(new { Name = new[] { "camaro", "monte carlo", "corvette" }, Year = 2000 }));
+
+                    Assert.NotNull(twoResults);
+                    Assert.Equal(2, twoResults.Hits.Count());
+                    Assert.Equal("Camaro", twoResults.Hits.First().Source.Name);
+                    Assert.Equal("Monte Carlo", twoResults.Hits.Last().Source.Name);
+                }
+            }
+        }
+
+        private class Car
+        {
+            [MappingAlias("name")]
+            public string Name { get; set; }
+
+            [MappingAlias("year")]
+            public int Year { get; set; }
+        }
+    }
+}

--- a/tests/Filter.Nest.Tests/packages.config
+++ b/tests/Filter.Nest.Tests/packages.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Elasticsearch.Net" version="2.4.5" targetFramework="net461" />
+  <package id="elasticsearch-inside" version="2.3.5" targetFramework="net461" />
+  <package id="NEST" version="2.4.5" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+  <package id="xunit" version="2.0.0" targetFramework="net461" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net461" />
+  <package id="xunit.assert" version="2.0.0" targetFramework="net461" />
+  <package id="xunit.core" version="2.0.0" targetFramework="net461" />
+  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net461" />
+  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
New behavior allows filtering related to the ElasticClient's SearchDescriptor instance.
Convention follows existing rules where applicable.
New attribute provided to allow defining storage of field in Elasticsearch index (due to case-sensitive querying).