### PR TITLE
Add filter value formatters, add boolean support

### DIFF
--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
-    <MinorVersion>7</MinorVersion>
+    <MinorVersion>8</MinorVersion>
     <PatchVersion>0</PatchVersion>
   </PropertyGroup>
 

--- a/tests/Filter.Nest.Tests/SearchDescriptorExtensionsTests.cs
+++ b/tests/Filter.Nest.Tests/SearchDescriptorExtensionsTests.cs
@@ -98,6 +98,108 @@ namespace Filter.Nest.Tests
                     Assert.Equal("Monte Carlo", twoResults.Hits.Last().Source.Name);
                 }
             }
+
+            [Fact]
+            public void Nullable_boolean_omitted_returns_expected_results()
+            {
+                using (var elasticsearch = new ElasticsearchInside.Elasticsearch())
+                {
+                    var elasticClient = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
+
+                    var camaro = new Car { Name = "Camaro", IsElectric = false };
+                    var volt = new Car { Name = "Volt", IsElectric = true };
+
+                    elasticClient.Index(camaro, x => x.Index("vehicles"));
+                    elasticClient.Index(volt, x => x.Index("vehicles"));
+
+                    elasticClient.Refresh("vehicles");
+
+                    var results = elasticClient
+                        .Search<Car>(x => x.Index("vehicles")
+                        .PostFilter(new { }));
+
+                    Assert.NotNull(results);
+                    Assert.Equal(2, results.Hits.Count());
+                    Assert.Equal("Camaro", results.Hits.First().Source.Name);
+                    Assert.Equal("Volt", results.Hits.Last().Source.Name);
+                }
+            }
+
+            [Fact]
+            public void Nullable_boolean_null_returns_expected_results()
+            {
+                using (var elasticsearch = new ElasticsearchInside.Elasticsearch())
+                {
+                    var elasticClient = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
+
+                    var camaro = new Car { Name = "Camaro", IsElectric = false };
+                    var volt = new Car { Name = "Volt", IsElectric = true };
+
+                    elasticClient.Index(camaro, x => x.Index("vehicles"));
+                    elasticClient.Index(volt, x => x.Index("vehicles"));
+
+                    elasticClient.Refresh("vehicles");
+
+                    var results = elasticClient
+                        .Search<Car>(x => x.Index("vehicles")
+                        .PostFilter(new { IsElectric = (bool?)null }));
+
+                    Assert.NotNull(results);
+                    Assert.Equal(2, results.Hits.Count());
+                    Assert.Equal("Camaro", results.Hits.First().Source.Name);
+                    Assert.Equal("Volt", results.Hits.Last().Source.Name);
+                }
+            }
+
+            [Fact]
+            public void Nullable_boolean_true_returns_expected_results()
+            {
+                using (var elasticsearch = new ElasticsearchInside.Elasticsearch())
+                {
+                    var elasticClient = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
+
+                    var camaro = new Car { Name = "Camaro", IsElectric = false };
+                    var volt = new Car { Name = "Volt", IsElectric = true };
+
+                    elasticClient.Index(camaro, x => x.Index("vehicles"));
+                    elasticClient.Index(volt, x => x.Index("vehicles"));
+
+                    elasticClient.Refresh("vehicles");
+
+                    var results = elasticClient
+                        .Search<Car>(x => x.Index("vehicles")
+                        .PostFilter(new { IsElectric = true }));
+
+                    Assert.NotNull(results);
+                    Assert.Equal(1, results.Hits.Count());
+                    Assert.Equal("Volt", results.Hits.First().Source.Name);
+                }
+            }
+
+            [Fact]
+            public void Nullable_boolean_false_returns_expected_results()
+            {
+                using (var elasticsearch = new ElasticsearchInside.Elasticsearch())
+                {
+                    var elasticClient = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
+
+                    var camaro = new Car { Name = "Camaro", IsElectric = false };
+                    var volt = new Car { Name = "Volt", IsElectric = true };
+
+                    elasticClient.Index(camaro, x => x.Index("vehicles"));
+                    elasticClient.Index(volt, x => x.Index("vehicles"));
+
+                    elasticClient.Refresh("vehicles");
+
+                    var results = elasticClient
+                        .Search<Car>(x => x.Index("vehicles")
+                        .PostFilter(new { IsElectric = false }));
+
+                    Assert.NotNull(results);
+                    Assert.Equal(1, results.Hits.Count());
+                    Assert.Equal("Camaro", results.Hits.First().Source.Name);
+                }
+            }
         }
 
         private class Car
@@ -107,6 +209,9 @@ namespace Filter.Nest.Tests
 
             [MappingAlias("year")]
             public int Year { get; set; }
+
+            [MappingAlias("isElectric")]
+            public bool IsElectric { get; set; }
         }
     }
 }


### PR DESCRIPTION
- Add `filterValueFormatters` optional parameter to `PostFilter<T>` extension method. By default, `DefaultFilterValueFormatters` is used which includes support for booleans.
- Version **0.8.0**