### PR TITLE
Include Referenced Projects in Nuget Pack

### DIFF
--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -2,8 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
-    <MinorVersion>8</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <MinorVersion>9</MinorVersion>
+    <PatchVersion>0</PatchVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/build/Build.msbuild
+++ b/build/Build.msbuild
@@ -57,6 +57,7 @@
     <ItemGroup>
       <NuSpecFiles Include="$(RootPath)src\*\*.nuspec" />
 
+      <NuGetArgs Include="-IncludeReferencedProjects" />
       <NuGetArgs Include="-Properties Configuration=$(Configuration)" />
       <NuGetArgs Include="-Version $(PackageVersion)" />
       <NuGetArgs Include="-OutputDirectory $(ArtifactsPath)" />


### PR DESCRIPTION
Added `IncludeReferencedProjects` as a nuget command property
which should include the necessary referenced projects. The only
issue I currently see is that `RimDev.Filter.Range.Web.Http` includes
a duplicate assembly `RimDev.Filter.Range`, which is included
in a dependency project.
