### PR TITLE
Use object property when applicable via FilterLogic

### DIFF
--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
-    <MinorVersion>10</MinorVersion>
+    <MinorVersion>11</MinorVersion>
     <PatchVersion>0</PatchVersion>
   </PropertyGroup>
 

--- a/src/Filter.Nest/FilterLogic.cs
+++ b/src/Filter.Nest/FilterLogic.cs
@@ -38,20 +38,28 @@ namespace RimDev.Filter.Nest
                 {
                     var queries = new List<Func<QueryContainerDescriptor<T>, QueryContainer>>();
                     var aliasAttribute = validValueProperty.GetCustomAttribute<MappingAliasAttribute>();
-                    var validValuePropertyName = aliasAttribute != null
-                        ? aliasAttribute.Alias
-                        : filterProperty.Name;
 
                     if (typeof(IEnumerable).IsAssignableFrom(filterProperty.PropertyType)
                         && filterProperty.PropertyType != typeof(string))
                     {
                         foreach (var item in (IEnumerable)filterPropertyValue)
                         {
-                            queries.Add(x =>
-                                x.Match(y =>
-                                    y
-                                        .Field(validValuePropertyName)
-                                        .Query(item.ToString())));
+                            if (aliasAttribute != null)
+                            {
+                                queries.Add(x =>
+                                    x.Match(y =>
+                                        y
+                                            .Field(aliasAttribute.Alias)
+                                            .Query(item.ToString())));
+                            }
+                            else
+                            {
+                                queries.Add(x =>
+                                    x.Match(y =>
+                                        y
+                                            .Field(validValueProperty)
+                                            .Query(item.ToString())));
+                            }
                         }
                     }
                     else
@@ -65,11 +73,22 @@ namespace RimDev.Filter.Nest
                             formatter = x => x.ToString();
                         }
 
-                        mustQueries.Add(x =>
-                            x.Match(y =>
-                                y
-                                    .Field(validValuePropertyName)
-                                    .Query(formatter(filterPropertyValue))));
+                        if (aliasAttribute != null)
+                        {
+                            mustQueries.Add(x =>
+                                x.Match(y =>
+                                    y
+                                        .Field(aliasAttribute.Alias)
+                                        .Query(formatter(filterPropertyValue))));
+                        }
+                        else
+                        {
+                            mustQueries.Add(x =>
+                                x.Match(y =>
+                                    y
+                                        .Field(validValueProperty)
+                                        .Query(formatter(filterPropertyValue))));
+                        }
                     }
 
                     mustQueries.Add(x =>

--- a/tests/Filter.Nest.Tests/Car.cs
+++ b/tests/Filter.Nest.Tests/Car.cs
@@ -1,16 +1,9 @@
-﻿using RimDev.Filter.Nest;
-
-namespace Filter.Nest.Tests
+﻿namespace Filter.Nest.Tests
 {
     public class Car
     {
-        [MappingAlias("name")]
         public string Name { get; set; }
-
-        [MappingAlias("year")]
         public int Year { get; set; }
-
-        [MappingAlias("isElectric")]
         public bool IsElectric { get; set; }
     }
 }


### PR DESCRIPTION
Previous behavior would either use the filter's property-name or applicable attribute alias when constructing NEST query.
However, NEST will auto-resolve property name-casing on the object directly, so new behavior uses the object's property when applicable.
Immediate benefit includes not needing to know NEST serialization settings within an app.
This reduces the need for the MappingAliasAttribute as a C# => Elasticsearch property-name case converter.

`filter.NAME`, `filter.name`, `filter.NaMe` will all work.