### PR TITLE
Add filtering to boolean queries

### DIFF
--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
-    <MinorVersion>11</MinorVersion>
+    <MinorVersion>12</MinorVersion>
     <PatchVersion>0</PatchVersion>
   </PropertyGroup>
 

--- a/src/Filter.Nest/BoolQueryDescriptorExtensions.cs
+++ b/src/Filter.Nest/BoolQueryDescriptorExtensions.cs
@@ -1,0 +1,31 @@
+﻿using Nest;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RimDev.Filter.Nest
+{
+    public static class BoolQueryDescriptorExtensions
+    {
+        public static BoolQueryDescriptor<T> Filter<T>(
+            this BoolQueryDescriptor<T> value,
+            object filter,
+            IDictionary<Type, Func<object, string>> filterValueFormatters = null)
+            where T : class
+        {
+            if (filter == null)
+            {
+                return value;
+            }
+
+            var mustQueries = FilterLogic.GenerateMustQueriesFromFilter<T>(filter, filterValueFormatters);
+
+            if (mustQueries.Any())
+            {
+                return value.Filter(mustQueries);
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/Filter.Nest/Filter.Nest.csproj
+++ b/src/Filter.Nest/Filter.Nest.csproj
@@ -57,6 +57,7 @@
     <Compile Include="MappingAliasAttribute.cs" />
     <Compile Include="NestFilterOptions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="BoolQueryDescriptorExtensions.cs" />
     <Compile Include="QueryContainerDescriptorExtensions.cs" />
     <Compile Include="SearchDescriptorExtensions.cs" />
   </ItemGroup>

--- a/tests/Filter.Nest.Tests/BoolQueryDescriptorExtensionsTests.cs
+++ b/tests/Filter.Nest.Tests/BoolQueryDescriptorExtensionsTests.cs
@@ -1,0 +1,201 @@
+﻿using Nest;
+using RimDev.Filter.Nest;
+using System.Linq;
+using Xunit;
+
+namespace Filter.Nest.Tests
+{
+    public class BoolQueryDescriptorExtensionsTests
+    {
+        public class Filter : SearchDescriptorExtensionsTests
+        {
+            [Fact]
+            public void Can_query_using_collection()
+            {
+                using (var elasticsearch = new ElasticsearchInside.Elasticsearch())
+                {
+                    var elasticClient = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
+
+                    var camaro = new Car { Name = "Camaro" };
+                    var corvette = new Car { Name = "Corvette" };
+                    var monteCarlo = new Car { Name = "Monte Carlo" };
+
+                    elasticClient.Index(camaro, x => x.Index("vehicles"));
+                    elasticClient.Index(corvette, x => x.Index("vehicles"));
+                    elasticClient.Index(monteCarlo, x => x.Index("vehicles"));
+
+                    elasticClient.Refresh("vehicles");
+
+                    var results = elasticClient.Search<Car>(s => s.Index("vehicles").Query(
+                        q => q.Bool(x => x.Filter(new { Name = new[] { "camaro", "monte carlo" } }))));
+
+                    Assert.NotNull(results);
+                    Assert.Equal(2, results.Hits.Count());
+
+                    var sortedSources = results.Hits.OrderBy(x => x.Source.Name).Select(x => x.Source);
+
+                    Assert.Equal("Camaro", sortedSources.First().Name);
+                    Assert.Equal("Monte Carlo", sortedSources.Last().Name);
+                }
+            }
+
+            [Fact]
+            public void Can_query_using_single_value()
+            {
+                using (var elasticsearch = new ElasticsearchInside.Elasticsearch())
+                {
+                    var elasticClient = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
+
+                    var camaro = new Car { Name = "Camaro" };
+                    var corvette = new Car { Name = "Corvette" };
+                    var monteCarlo = new Car { Name = "Monte Carlo" };
+
+                    elasticClient.Index(camaro, x => x.Index("vehicles"));
+                    elasticClient.Index(corvette, x => x.Index("vehicles"));
+                    elasticClient.Index(monteCarlo, x => x.Index("vehicles"));
+
+                    elasticClient.Refresh("vehicles");
+                    
+                    var results = elasticClient.Search<Car>(s => s.Index("vehicles").Query(
+                        q => q.Bool(x => x.Filter(new { Name = new[] { "camaro" } }))));
+
+                    Assert.NotNull(results);
+                    Assert.Equal(1, results.Hits.Count());
+                    Assert.Equal("Camaro", results.Hits.First().Source.Name);
+                }
+            }
+
+            [Fact]
+            public void Multiple_filter_properties_queried_as_collection_of_and_operators()
+            {
+                using (var elasticsearch = new ElasticsearchInside.Elasticsearch())
+                {
+                    var elasticClient = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
+
+                    var camaro = new Car { Name = "Camaro", Year = 2000 };
+                    var corvette = new Car { Name = "Corvette", Year = 2016 };
+                    var monteCarlo = new Car { Name = "Monte Carlo", Year = 2000 };
+
+                    elasticClient.Index(camaro, x => x.Index("vehicles"));
+                    elasticClient.Index(corvette, x => x.Index("vehicles"));
+                    elasticClient.Index(monteCarlo, x => x.Index("vehicles"));
+
+                    elasticClient.Refresh("vehicles");
+
+                    var noResults = elasticClient.Search<Car>(s => s.Index("vehicles").Query(
+                        q => q.Bool(x => x.Filter(new { Name = new[] { "camaro", "monte carlo" }, Year = 2016 }))));
+
+                    Assert.NotNull(noResults);
+                    Assert.Equal(0, noResults.Hits.Count());
+
+                    var twoResults = elasticClient
+                        .Search<Car>(x => x.Index("vehicles")
+                        .PostFilter(new { Name = new[] { "camaro", "monte carlo", "corvette" }, Year = 2000 }));
+
+                    Assert.NotNull(twoResults);
+                    Assert.Equal(2, twoResults.Hits.Count());
+                    Assert.Equal("Camaro", twoResults.Hits.First().Source.Name);
+                    Assert.Equal("Monte Carlo", twoResults.Hits.Last().Source.Name);
+                }
+            }
+
+            [Fact]
+            public void Nullable_boolean_omitted_returns_expected_results()
+            {
+                using (var elasticsearch = new ElasticsearchInside.Elasticsearch())
+                {
+                    var elasticClient = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
+
+                    var camaro = new Car { Name = "Camaro", IsElectric = false };
+                    var volt = new Car { Name = "Volt", IsElectric = true };
+
+                    elasticClient.Index(camaro, x => x.Index("vehicles"));
+                    elasticClient.Index(volt, x => x.Index("vehicles"));
+
+                    elasticClient.Refresh("vehicles");
+
+                    var results = elasticClient.Search<Car>(s => s.Index("vehicles").Query(
+                        q => q.MatchAll() && q.Bool(x => x.Filter(new { }))));
+
+                    Assert.NotNull(results);
+                    Assert.Equal(2, results.Hits.Count());
+                    Assert.Equal("Camaro", results.Hits.First().Source.Name);
+                    Assert.Equal("Volt", results.Hits.Last().Source.Name);
+                }
+            }
+
+            [Fact]
+            public void Nullable_boolean_null_returns_expected_results()
+            {
+                using (var elasticsearch = new ElasticsearchInside.Elasticsearch())
+                {
+                    var elasticClient = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
+
+                    var camaro = new Car { Name = "Camaro", IsElectric = false };
+                    var volt = new Car { Name = "Volt", IsElectric = true };
+
+                    elasticClient.Index(camaro, x => x.Index("vehicles"));
+                    elasticClient.Index(volt, x => x.Index("vehicles"));
+
+                    elasticClient.Refresh("vehicles");
+
+                    var results = elasticClient.Search<Car>(s => s.Index("vehicles").Query(
+                        q => q.MatchAll() && q.Bool(x => x.Filter(new { IsElectric = (bool?)null }))));
+
+                    Assert.NotNull(results);
+                    Assert.Equal(2, results.Hits.Count());
+                    Assert.Equal("Camaro", results.Hits.First().Source.Name);
+                    Assert.Equal("Volt", results.Hits.Last().Source.Name);
+                }
+            }
+
+            [Fact]
+            public void Nullable_boolean_true_returns_expected_results()
+            {
+                using (var elasticsearch = new ElasticsearchInside.Elasticsearch())
+                {
+                    var elasticClient = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
+
+                    var camaro = new Car { Name = "Camaro", IsElectric = false };
+                    var volt = new Car { Name = "Volt", IsElectric = true };
+
+                    elasticClient.Index(camaro, x => x.Index("vehicles"));
+                    elasticClient.Index(volt, x => x.Index("vehicles"));
+
+                    elasticClient.Refresh("vehicles");
+
+                    var results = elasticClient.Search<Car>(s => s.Index("vehicles").Query(
+                        q => q.Bool(x => x.Filter(new { IsElectric = true }))));
+
+                    Assert.NotNull(results);
+                    Assert.Equal(1, results.Hits.Count());
+                    Assert.Equal("Volt", results.Hits.First().Source.Name);
+                }
+            }
+
+            [Fact]
+            public void Nullable_boolean_false_returns_expected_results()
+            {
+                using (var elasticsearch = new ElasticsearchInside.Elasticsearch())
+                {
+                    var elasticClient = new ElasticClient(new ConnectionSettings(elasticsearch.Url));
+
+                    var camaro = new Car { Name = "Camaro", IsElectric = false };
+                    var volt = new Car { Name = "Volt", IsElectric = true };
+
+                    elasticClient.Index(camaro, x => x.Index("vehicles"));
+                    elasticClient.Index(volt, x => x.Index("vehicles"));
+
+                    elasticClient.Refresh("vehicles");
+
+                    var results = elasticClient.Search<Car>(s => s.Index("vehicles").Query(
+                        q => q.Bool(x => x.Filter(new { IsElectric = false }))));
+
+                    Assert.NotNull(results);
+                    Assert.Equal(1, results.Hits.Count());
+                    Assert.Equal("Camaro", results.Hits.First().Source.Name);
+                }
+            }
+        }
+    }
+}

--- a/tests/Filter.Nest.Tests/Filter.Nest.Tests.csproj
+++ b/tests/Filter.Nest.Tests/Filter.Nest.Tests.csproj
@@ -74,6 +74,7 @@
   <ItemGroup>
     <Compile Include="Car.cs" />
     <Compile Include="MappingAliasAttributeTests.cs" />
+    <Compile Include="BoolQueryDescriptorExtensionsTests.cs" />
     <Compile Include="QueryContainerDescriptorExtensionsTests.cs" />
     <Compile Include="SearchDescriptorExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
`BoolQueryDescriptor<T>` already has several filter methods. This just incorporates the project's existing filtering logic as an extension to the class.