### PR TITLE
[WIP] Upgrade

### DIFF
--- a/samples/Range.Web.Http/Range.Web.Http.csproj
+++ b/samples/Range.Web.Http/Range.Web.Http.csproj
@@ -13,13 +13,14 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Range.Web.Http</RootNamespace>
     <AssemblyName>Range.Web.Http</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -75,9 +76,6 @@
     <Reference Include="System.Web.Http.WebHost, Version=__MvcPagesVersion__, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.2\lib\net45\System.Web.Http.WebHost.dll</HintPath>
     </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="App_Data\" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App_Start\WebApiConfig.cs" />

--- a/src/Filter.Nest/Filter.Nest.csproj
+++ b/src/Filter.Nest/Filter.Nest.csproj
@@ -65,6 +65,12 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Range\Range.csproj">
+      <Project>{0e804077-79b6-4e0f-a4bb-ad5f6ec194b3}</Project>
+      <Name>Range</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Filter.Nest/Filter.Nest.csproj
+++ b/src/Filter.Nest/Filter.Nest.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RimDev.Filter.Nest</RootNamespace>
     <AssemblyName>RimDev.Filter.Nest</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,12 +32,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Elasticsearch.Net, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Elasticsearch.Net.2.4.5\lib\net45\Elasticsearch.Net.dll</HintPath>
+    <Reference Include="Elasticsearch.Net, Version=6.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d">
+      <HintPath>..\..\packages\Elasticsearch.Net.6.3.0\lib\net461\Elasticsearch.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Nest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NEST.2.4.5\lib\net45\Nest.dll</HintPath>
+    <Reference Include="Nest, Version=6.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d">
+      <HintPath>..\..\packages\NEST.6.3.0\lib\net461\Nest.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/Filter.Nest/FilterLogic.cs
+++ b/src/Filter.Nest/FilterLogic.cs
@@ -39,6 +39,12 @@ namespace RimDev.Filter.Nest
                     var queries = new List<Func<QueryContainerDescriptor<T>, QueryContainer>>();
                     var aliasAttribute = validValueProperty.GetCustomAttribute<MappingAliasAttribute>();
 
+                    if (typeof(Range.Generic.IRange<>).IsAssignableFrom(filterProperty.PropertyType))
+                    {
+                        
+                        
+                    }
+                    else
                     if (typeof(IEnumerable).IsAssignableFrom(filterProperty.PropertyType)
                         && filterProperty.PropertyType != typeof(string))
                     {

--- a/src/Filter.Nest/packages.config
+++ b/src/Filter.Nest/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Elasticsearch.Net" version="2.4.5" targetFramework="net45" />
-  <package id="NEST" version="2.4.5" targetFramework="net45" />
+  <package id="Elasticsearch.Net" version="6.3.0" targetFramework="net462" />
+  <package id="NEST" version="6.3.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
 </packages>

--- a/src/Filter/Filter.csproj
+++ b/src/Filter/Filter.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RimDev.Filter</RootNamespace>
     <AssemblyName>RimDev.Filter</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Range.Web.Http/Range.Web.Http.csproj
+++ b/src/Range.Web.Http/Range.Web.Http.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RimDev.Filter.Range.Web.Http</RootNamespace>
     <AssemblyName>RimDev.Filter.Range.Web.Http</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Range/Range.cs
+++ b/src/Range/Range.cs
@@ -151,5 +151,53 @@ namespace RimDev.Filter.Range
 
             return result != null;
         }
+
+        public static Range<DateTimeOffset> AsDateRange(object range)
+        {
+            if (range == null)
+                return null;
+
+            switch (IsDateRange(range))
+            {
+                case true when range is Range<DateTime> dt:
+                    return new Range<DateTimeOffset> {
+                        IsMaxInclusive = dt.IsMaxInclusive,
+                        IsMinInclusive = dt.IsMinInclusive,
+                        MinValue = dt.MinValue.HasValue ? 
+                            new DateTimeOffset(dt.MinValue.Value, TimeSpan.Zero) 
+                            : (DateTimeOffset?) null,
+                        MaxValue = dt.MaxValue.HasValue ? 
+                            new DateTimeOffset(dt.MaxValue.Value, TimeSpan.Zero) 
+                            : (DateTimeOffset?) null,
+                    };
+                case true when range is Range<DateTimeOffset> dto:
+                    return dto;
+                default:
+                    return null;
+            }
+        }
+        
+        public static Range<decimal> AsNumericRange(object range)
+        {
+            if (range == null || !IsNumericRange(range))
+                return null;
+            
+            dynamic r = range;
+            
+            // Using decimal for precision 
+            var numeric = new Range<decimal>()
+            {
+                IsMaxInclusive = r.IsMaxInclusive,
+                IsMinInclusive = r.IsMinInclusive,
+                MinValue = r.MinValue == null
+                    ? (decimal?) null 
+                    : SmartConverter.Convert<decimal>(r.MinValue.ToString()),
+                MaxValue = r.MaxValue == null
+                    ? (decimal?) null 
+                    : SmartConverter.Convert<decimal>(r.MaxValue.ToString()) 
+            };
+
+            return numeric;
+        }
     }
 }

--- a/src/Range/Range.cs
+++ b/src/Range/Range.cs
@@ -1,6 +1,7 @@
 ﻿using RimDev.Filter.Range.Generic;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace RimDev.Filter.Range
@@ -115,6 +116,38 @@ namespace RimDev.Filter.Range
             }
 
             return range;
+        }
+
+        public static bool IsDateRange<T>(this IRange<T> range) 
+            where T : struct
+        {
+            var x = typeof(T);
+            var t = Nullable.GetUnderlyingType(x) ?? x;
+            var result = t == typeof(DateTime) || t == typeof(DateTimeOffset);
+            return result;
+        }
+
+        public static bool IsNumericRange<T>(this IRange<T> range) 
+            where T : struct
+        {
+            var numbers = new[] {
+                typeof(sbyte),
+                typeof(short),
+                typeof(int),
+                typeof(long),
+                typeof(byte),
+                typeof(ushort),
+                typeof(uint),
+                typeof(ulong),
+                typeof(float),
+                typeof(double),
+                typeof(decimal)
+            };
+            
+            var x = typeof(T);
+            var t = Nullable.GetUnderlyingType(x) ?? x;
+            var result = numbers.Contains(t);
+            return result;
         }
     }
 }

--- a/src/Range/Range.cs
+++ b/src/Range/Range.cs
@@ -118,19 +118,16 @@ namespace RimDev.Filter.Range
             return range;
         }
 
-        public static bool IsDateRange<T>(this IRange<T> range) 
-            where T : struct
+        public static bool IsDateRange(object range)
         {
-            var x = typeof(T);
-            var t = Nullable.GetUnderlyingType(x) ?? x;
-            var result = t == typeof(DateTime) || t == typeof(DateTimeOffset);
-            return result;
+            return range is Range<DateTimeOffset> || range is Range<DateTime>;
         }
-
-        public static bool IsNumericRange<T>(this IRange<T> range) 
-            where T : struct
+               
+        public static bool IsNumericRange(object range)
         {
-            var numbers = new[] {
+            var rangeDefinition = typeof(Range<>);
+            var numbers = new[] 
+            {
                 typeof(sbyte),
                 typeof(short),
                 typeof(int),
@@ -143,11 +140,16 @@ namespace RimDev.Filter.Range
                 typeof(double),
                 typeof(decimal)
             };
-            
-            var x = typeof(T);
-            var t = Nullable.GetUnderlyingType(x) ?? x;
-            var result = numbers.Contains(t);
-            return result;
+
+            if (range == null)
+                return false;
+
+            var target = range.GetType();
+            var result = numbers
+                .Select(type => rangeDefinition.MakeGenericType(type))
+                .FirstOrDefault(type => target == type);
+
+            return result != null;
         }
     }
 }

--- a/src/Range/Range.csproj
+++ b/src/Range/Range.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RimDev.Filter.Range</RootNamespace>
     <AssemblyName>RimDev.Filter.Range</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/Filter.Nest.Tests/Car.cs
+++ b/tests/Filter.Nest.Tests/Car.cs
@@ -1,9 +1,12 @@
-﻿namespace Filter.Nest.Tests
+﻿using System;
+
+namespace Filter.Nest.Tests
 {
     public class Car
     {
-        public string Name { get; set; }
-        public int Year { get; set; }
         public bool IsElectric { get; set; }
+        public string Name { get; set; }
+        public DateTimeOffset StartProductionRun { get; set; }
+        public int Year { get; set; }
     }
 }

--- a/tests/Filter.Nest.Tests/Filter.Nest.Tests.csproj
+++ b/tests/Filter.Nest.Tests/Filter.Nest.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props')" />
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -103,9 +103,9 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props'))" />
     <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props'))" />
     <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <Import Project="..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/tests/Filter.Nest.Tests/Filter.Nest.Tests.csproj
+++ b/tests/Filter.Nest.Tests/Filter.Nest.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" />
   <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -62,16 +62,16 @@
       <HintPath>..\..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.4.1.4059, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
-      <HintPath>..\..\packages\xunit.assert.2.4.1-pre.build.4059\lib\netstandard2.0\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.assert.2.4.0\lib\netstandard2.0\xunit.assert.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.4.1.4059, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.4.1-pre.build.4059\lib\net452\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.4.0\lib\net452\xunit.core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.4.1.4059, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
-      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.1-pre.build.4059\lib\net452\xunit.execution.desktop.dll</HintPath>
+    <Reference Include="xunit.execution.desktop, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.0\lib\net452\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -103,11 +103,11 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets'))" />
     <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.targets'))" />
   </Target>
-  <Import Project="..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets')" />
+  <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/tests/Filter.Nest.Tests/Filter.Nest.Tests.csproj
+++ b/tests/Filter.Nest.Tests/Filter.Nest.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
+  <Import Project="..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props')" />
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -58,16 +58,20 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.4.1.4059, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.assert.2.4.1-pre.build.4059\lib\netstandard2.0\xunit.assert.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.4.1.4059, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.4.1-pre.build.4059\lib\net452\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.4.1.4059, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.1-pre.build.4059\lib\net452\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -91,14 +95,19 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.10.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets'))" />
   </Target>
+  <Import Project="..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/tests/Filter.Nest.Tests/Filter.Nest.Tests.csproj
+++ b/tests/Filter.Nest.Tests/Filter.Nest.Tests.csproj
@@ -91,6 +91,10 @@
       <Project>{39ac08c4-a82d-45f7-bbf2-f239028e6d85}</Project>
       <Name>Filter.Nest</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\Range\Range.csproj">
+      <Project>{0e804077-79b6-4e0f-a4bb-ad5f6ec194b3}</Project>
+      <Name>Range</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/Filter.Nest.Tests/Filter.Nest.Tests.csproj
+++ b/tests/Filter.Nest.Tests/Filter.Nest.Tests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Filter.Nest.Tests</RootNamespace>
     <AssemblyName>Filter.Nest.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
@@ -34,16 +34,16 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Elasticsearch.Net, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Elasticsearch.Net.2.4.5\lib\net46\Elasticsearch.Net.dll</HintPath>
+    <Reference Include="Elasticsearch.Net, Version=6.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d">
+      <HintPath>..\..\packages\Elasticsearch.Net.6.3.0\lib\net461\Elasticsearch.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="ElasticsearchInside, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\elasticsearch-inside.2.3.5\lib\net451\ElasticsearchInside.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Nest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NEST.2.4.5\lib\net46\Nest.dll</HintPath>
+    <Reference Include="Nest, Version=6.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d">
+      <HintPath>..\..\packages\NEST.6.3.0\lib\net461\Nest.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/tests/Filter.Nest.Tests/packages.config
+++ b/tests/Filter.Nest.Tests/packages.config
@@ -11,5 +11,5 @@
   <package id="xunit.core" version="2.4.1-pre.build.4059" targetFramework="net462" />
   <package id="xunit.extensibility.core" version="2.4.1-pre.build.4059" targetFramework="net462" />
   <package id="xunit.extensibility.execution" version="2.4.1-pre.build.4059" targetFramework="net462" />
-  <package id="xunit.runner.visualstudio" version="2.4.1-pre.build.4059" targetFramework="net462" developmentDependency="true" />
+  <package id="xunit.runner.visualstudio" version="2.4.0" targetFramework="net462" developmentDependency="true" />
 </packages>

--- a/tests/Filter.Nest.Tests/packages.config
+++ b/tests/Filter.Nest.Tests/packages.config
@@ -4,12 +4,12 @@
   <package id="elasticsearch-inside" version="2.3.5" targetFramework="net461" />
   <package id="NEST" version="6.3.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
-  <package id="xunit" version="2.4.1-pre.build.4059" targetFramework="net462" />
+  <package id="xunit" version="2.4.0" targetFramework="net462" />
   <package id="xunit.abstractions" version="2.0.3" targetFramework="net462" />
   <package id="xunit.analyzers" version="0.10.0" targetFramework="net462" />
-  <package id="xunit.assert" version="2.4.1-pre.build.4059" targetFramework="net462" />
-  <package id="xunit.core" version="2.4.1-pre.build.4059" targetFramework="net462" />
-  <package id="xunit.extensibility.core" version="2.4.1-pre.build.4059" targetFramework="net462" />
-  <package id="xunit.extensibility.execution" version="2.4.1-pre.build.4059" targetFramework="net462" />
+  <package id="xunit.assert" version="2.4.0" targetFramework="net462" />
+  <package id="xunit.core" version="2.4.0" targetFramework="net462" />
+  <package id="xunit.extensibility.core" version="2.4.0" targetFramework="net462" />
+  <package id="xunit.extensibility.execution" version="2.4.0" targetFramework="net462" />
   <package id="xunit.runner.visualstudio" version="2.4.0" targetFramework="net462" developmentDependency="true" />
 </packages>

--- a/tests/Filter.Nest.Tests/packages.config
+++ b/tests/Filter.Nest.Tests/packages.config
@@ -4,10 +4,12 @@
   <package id="elasticsearch-inside" version="2.3.5" targetFramework="net461" />
   <package id="NEST" version="6.3.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
-  <package id="xunit" version="2.0.0" targetFramework="net461" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net461" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net461" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net461" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net461" />
-  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net461" />
+  <package id="xunit" version="2.4.1-pre.build.4059" targetFramework="net462" />
+  <package id="xunit.abstractions" version="2.0.3" targetFramework="net462" />
+  <package id="xunit.analyzers" version="0.10.0" targetFramework="net462" />
+  <package id="xunit.assert" version="2.4.1-pre.build.4059" targetFramework="net462" />
+  <package id="xunit.core" version="2.4.1-pre.build.4059" targetFramework="net462" />
+  <package id="xunit.extensibility.core" version="2.4.1-pre.build.4059" targetFramework="net462" />
+  <package id="xunit.extensibility.execution" version="2.4.1-pre.build.4059" targetFramework="net462" />
+  <package id="xunit.runner.visualstudio" version="2.4.1-pre.build.4059" targetFramework="net462" developmentDependency="true" />
 </packages>

--- a/tests/Filter.Nest.Tests/packages.config
+++ b/tests/Filter.Nest.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Elasticsearch.Net" version="2.4.5" targetFramework="net461" />
+  <package id="Elasticsearch.Net" version="6.3.0" targetFramework="net461" />
   <package id="elasticsearch-inside" version="2.3.5" targetFramework="net461" />
-  <package id="NEST" version="2.4.5" targetFramework="net461" />
+  <package id="NEST" version="6.3.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="xunit" version="2.0.0" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net461" />

--- a/tests/Filter.Tests/Filter.Tests.csproj
+++ b/tests/Filter.Tests/Filter.Tests.csproj
@@ -12,9 +12,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RimDev.Filter.Tests</RootNamespace>
     <AssemblyName>RimDev.Filter.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>0af85866</NuGetPackageImportStamp>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/Filter.Tests/Filter.Tests.csproj
+++ b/tests/Filter.Tests/Filter.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props')" />
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props" Condition="Exists('..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -106,9 +106,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props'))" />
     <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props'))" />
     <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <Import Project="..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/tests/Filter.Tests/Filter.Tests.csproj
+++ b/tests/Filter.Tests/Filter.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props')" />
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props" Condition="Exists('..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props')" />
-  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -54,14 +54,21 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit.abstractions">
-      <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert">
-      <HintPath>..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.4.1.4059, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.assert.2.4.1-pre.build.4059\lib\netstandard2.0\xunit.assert.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.4.1.4059, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.4.1-pre.build.4059\lib\net452\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.4.1.4059, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.1-pre.build.4059\lib\net452\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -90,15 +97,20 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.10.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
     <Error Condition="!Exists('..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets'))" />
   </Target>
+  <Import Project="..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/tests/Filter.Tests/Filter.Tests.csproj
+++ b/tests/Filter.Tests/Filter.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" />
+  <Import Project="..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.props" Condition="Exists('..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.props')" />
   <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props')" />
-  <Import Project="..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props" Condition="Exists('..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -58,16 +58,16 @@
       <HintPath>..\..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.4.1.4059, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
-      <HintPath>..\..\packages\xunit.assert.2.4.1-pre.build.4059\lib\netstandard2.0\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.assert.2.4.0\lib\netstandard2.0\xunit.assert.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.4.1.4059, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.4.1-pre.build.4059\lib\net452\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.4.0\lib\net452\xunit.core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.4.1.4059, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
-      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.1-pre.build.4059\lib\net452\xunit.execution.desktop.dll</HintPath>
+    <Reference Include="xunit.execution.desktop, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.0\lib\net452\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -105,12 +105,14 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets'))" />
     <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.targets'))" />
   </Target>
-  <Import Project="..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets')" />
+  <Import Project="..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.targets" Condition="Exists('..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.targets')" />
+  <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/tests/Filter.Tests/Generic/IEnumerable`1ExtensionsTests.cs
+++ b/tests/Filter.Tests/Generic/IEnumerable`1ExtensionsTests.cs
@@ -60,7 +60,7 @@ namespace RimDev.Filter.Tests.Generic
                 });
 
                 Assert.NotNull(@return);
-                Assert.Equal(1, @return.Count());
+                Assert.Single(@return);
                 Assert.Equal("John", @return.First().FirstName);
             }
 
@@ -73,7 +73,7 @@ namespace RimDev.Filter.Tests.Generic
                 });
 
                 Assert.NotNull(@return);
-                Assert.Equal(1, @return.Count());
+                Assert.Single(@return);
                 Assert.Equal("John", @return.First().FirstName);
             }
 

--- a/tests/Filter.Tests/packages.config
+++ b/tests/Filter.Tests/packages.config
@@ -2,11 +2,13 @@
 <packages>
   <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
   <package id="System.Data.SqlLocalDb" version="1.15.0" targetFramework="net45" />
-  <package id="xunit" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit" version="2.4.1-pre.build.4059" targetFramework="net462" />
+  <package id="xunit.abstractions" version="2.0.3" targetFramework="net462" />
+  <package id="xunit.analyzers" version="0.10.0" targetFramework="net462" />
+  <package id="xunit.assert" version="2.4.1-pre.build.4059" targetFramework="net462" />
+  <package id="xunit.core" version="2.4.1-pre.build.4059" targetFramework="net462" />
+  <package id="xunit.extensibility.core" version="2.4.1-pre.build.4059" targetFramework="net462" />
+  <package id="xunit.extensibility.execution" version="2.4.1-pre.build.4059" targetFramework="net462" />
   <package id="xunit.runner.msbuild" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.4.1-pre.build.4059" targetFramework="net462" developmentDependency="true" />
 </packages>

--- a/tests/Filter.Tests/packages.config
+++ b/tests/Filter.Tests/packages.config
@@ -10,5 +10,5 @@
   <package id="xunit.extensibility.core" version="2.4.1-pre.build.4059" targetFramework="net462" />
   <package id="xunit.extensibility.execution" version="2.4.1-pre.build.4059" targetFramework="net462" />
   <package id="xunit.runner.msbuild" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.runner.visualstudio" version="2.4.1-pre.build.4059" targetFramework="net462" developmentDependency="true" />
+  <package id="xunit.runner.visualstudio" version="2.4.0" targetFramework="net462" developmentDependency="true" />
 </packages>

--- a/tests/Filter.Tests/packages.config
+++ b/tests/Filter.Tests/packages.config
@@ -2,13 +2,13 @@
 <packages>
   <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
   <package id="System.Data.SqlLocalDb" version="1.15.0" targetFramework="net45" />
-  <package id="xunit" version="2.4.1-pre.build.4059" targetFramework="net462" />
+  <package id="xunit" version="2.4.0" targetFramework="net462" />
   <package id="xunit.abstractions" version="2.0.3" targetFramework="net462" />
   <package id="xunit.analyzers" version="0.10.0" targetFramework="net462" />
-  <package id="xunit.assert" version="2.4.1-pre.build.4059" targetFramework="net462" />
-  <package id="xunit.core" version="2.4.1-pre.build.4059" targetFramework="net462" />
-  <package id="xunit.extensibility.core" version="2.4.1-pre.build.4059" targetFramework="net462" />
-  <package id="xunit.extensibility.execution" version="2.4.1-pre.build.4059" targetFramework="net462" />
-  <package id="xunit.runner.msbuild" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.4.0" targetFramework="net462" />
+  <package id="xunit.core" version="2.4.0" targetFramework="net462" />
+  <package id="xunit.extensibility.core" version="2.4.0" targetFramework="net462" />
+  <package id="xunit.extensibility.execution" version="2.4.0" targetFramework="net462" />
+  <package id="xunit.runner.msbuild" version="2.4.0" targetFramework="net462" developmentDependency="true" />
   <package id="xunit.runner.visualstudio" version="2.4.0" targetFramework="net462" developmentDependency="true" />
 </packages>

--- a/tests/Range.Tests/Generic/Range`1Tests.cs
+++ b/tests/Range.Tests/Generic/Range`1Tests.cs
@@ -53,8 +53,8 @@ namespace RimDev.Filter.Range.Tests.Generic
         {
             var dateTimeRange = new Range<DateTimeOffset>
             {
-                MinValue = new DateTime(2000, 1, 1),
-                MaxValue = new DateTime(2020, 1, 1)
+                MinValue = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                MaxValue = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero)
             } as object;
             
             var result = Range.AsDateRange(dateTimeRange);

--- a/tests/Range.Tests/Generic/Range`1Tests.cs
+++ b/tests/Range.Tests/Generic/Range`1Tests.cs
@@ -34,6 +34,58 @@ namespace RimDev.Filter.Range.Tests.Generic
         }
         
         [Fact]
+        public void Should_convert_object_that_is_date_range_to_datetimeoffset_range()
+        {
+            var dateTimeRange = new Range<DateTime>
+            {
+                MinValue = new DateTime(2000, 1, 1),
+                MaxValue = new DateTime(2020, 1, 1)
+            } as object;
+            
+            var result = Range.AsDateRange(dateTimeRange);
+            
+            Assert.Equal(2000, result.MinValue.Value.Year);
+            Assert.Equal(2020, result.MaxValue.Value.Year);
+        }
+        
+        [Fact]
+        public void Should_convert_object_that_is_datetimeoffset_range_to_datetimeoffset_range()
+        {
+            var dateTimeRange = new Range<DateTimeOffset>
+            {
+                MinValue = new DateTime(2000, 1, 1),
+                MaxValue = new DateTime(2020, 1, 1)
+            } as object;
+            
+            var result = Range.AsDateRange(dateTimeRange);
+            
+            Assert.Equal(2000, result.MinValue.Value.Year);
+            Assert.Equal(2020, result.MaxValue.Value.Year);
+        }
+        
+        [Fact]
+        public void Should_convert_object_that_is_int_range_to_decimal_range()
+        {
+            var dateTimeRange = new Range<int>
+            {
+                MinValue = 1,
+                MaxValue = 10
+            } as object;
+            
+            var result = Range.AsNumericRange(dateTimeRange);
+            
+            Assert.Equal(1, result.MinValue.Value);
+            Assert.Equal(10, result.MaxValue.Value);
+        }
+        
+        [Fact]
+        public void Should_convert_null_to_null()
+        {
+            Assert.Null(Range.AsNumericRange(null));
+            Assert.Null(Range.AsDateRange(null));
+        }
+        
+        [Fact]
         public void Should_determine_object_as_numeric_range()
         {
             var numericRange = new Range<int>() as object;

--- a/tests/Range.Tests/Generic/Range`1Tests.cs
+++ b/tests/Range.Tests/Generic/Range`1Tests.cs
@@ -1,31 +1,53 @@
-﻿using RimDev.Filter.Range.Generic;
+﻿using System;
+using RimDev.Filter.Range.Generic;
 using Xunit;
 
 namespace RimDev.Filter.Range.Tests.Generic
 {
     public class Range_1Tests
     {
-        public class Constructor
+        [Fact]
+        public void Should_hydrate_new_instance()
         {
-            [Fact]
-            public void Should_hydrate_new_instance()
+            var range = new Range<int>()
             {
-                var range = new Range<int>()
-                {
-                    MinValue = 5,
-                    MaxValue = 10,
-                    IsMinInclusive = true,
-                    IsMaxInclusive = true
-                };
+                MinValue = 5,
+                MaxValue = 10,
+                IsMinInclusive = true,
+                IsMaxInclusive = true
+            };
 
-                var sut = new Range<int>(range);
+            var sut = new Range<int>(range);
 
-                Assert.NotNull(sut);
-                Assert.Equal(5, sut.MinValue);
-                Assert.Equal(10, sut.MaxValue);
-                Assert.Equal(true, sut.IsMinInclusive);
-                Assert.Equal(true, sut.IsMaxInclusive);
-            }
+            Assert.NotNull(sut);
+            Assert.Equal(5, sut.MinValue);
+            Assert.Equal(10, sut.MaxValue);
+            Assert.True(sut.IsMinInclusive);
+            Assert.True(sut.IsMaxInclusive);
+        }
+    
+        [Fact]
+        public void Should_determine_range_as_date_range()
+        {
+            var dateTimeRange = new Range<DateTime>();
+            var dateTimeOffsetRange = new Range<DateTimeOffset>();
+            var intRange = new Range<int>();
+
+            Assert.True(dateTimeRange.IsDateRange());
+            Assert.True(dateTimeOffsetRange.IsDateRange());
+            Assert.False(intRange.IsDateRange());
+        }
+        
+        [Fact]
+        public void Should_determine_range_as_numeric_range()
+        {
+            var floatRange = new Range<float>();
+            var intRange = new Range<int>();
+            var dateRange = new Range<DateTime>();
+
+            Assert.True(floatRange.IsNumericRange());
+            Assert.True(intRange.IsNumericRange());
+            Assert.False(dateRange.IsNumericRange());
         }
     }
 }

--- a/tests/Range.Tests/Generic/Range`1Tests.cs
+++ b/tests/Range.Tests/Generic/Range`1Tests.cs
@@ -25,29 +25,19 @@ namespace RimDev.Filter.Range.Tests.Generic
             Assert.True(sut.IsMinInclusive);
             Assert.True(sut.IsMaxInclusive);
         }
-    
+        
         [Fact]
-        public void Should_determine_range_as_date_range()
+        public void Should_determine_object_as_date_range()
         {
-            var dateTimeRange = new Range<DateTime>();
-            var dateTimeOffsetRange = new Range<DateTimeOffset>();
-            var intRange = new Range<int>();
-
-            Assert.True(dateTimeRange.IsDateRange());
-            Assert.True(dateTimeOffsetRange.IsDateRange());
-            Assert.False(intRange.IsDateRange());
+            var dateTimeRange = new Range<DateTime>() as object;
+            Assert.True(Range.IsDateRange(dateTimeRange));
         }
         
         [Fact]
-        public void Should_determine_range_as_numeric_range()
+        public void Should_determine_object_as_numeric_range()
         {
-            var floatRange = new Range<float>();
-            var intRange = new Range<int>();
-            var dateRange = new Range<DateTime>();
-
-            Assert.True(floatRange.IsNumericRange());
-            Assert.True(intRange.IsNumericRange());
-            Assert.False(dateRange.IsNumericRange());
+            var numericRange = new Range<int>() as object;
+            Assert.True(Range.IsNumericRange(numericRange));
         }
     }
 }

--- a/tests/Range.Tests/Range.Tests.csproj
+++ b/tests/Range.Tests/Range.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props')" />
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props" Condition="Exists('..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props')" />
-  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -42,14 +42,21 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit.abstractions">
-      <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert">
-      <HintPath>..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.4.1.4059, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.assert.2.4.1-pre.build.4059\lib\netstandard2.0\xunit.assert.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.4.1.4059, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.4.1-pre.build.4059\lib\net452\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.4.1.4059, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.1-pre.build.4059\lib\net452\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -69,15 +76,20 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.10.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
     <Error Condition="!Exists('..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets'))" />
   </Target>
+  <Import Project="..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/tests/Range.Tests/Range.Tests.csproj
+++ b/tests/Range.Tests/Range.Tests.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RimDev.Filter.Range.Tests</RootNamespace>
     <AssemblyName>RimDev.Filter.Range.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>2fbf3947</NuGetPackageImportStamp>
   </PropertyGroup>

--- a/tests/Range.Tests/Range.Tests.csproj
+++ b/tests/Range.Tests/Range.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" />
+  <Import Project="..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.props" Condition="Exists('..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.props')" />
   <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props')" />
-  <Import Project="..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props" Condition="Exists('..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -46,16 +46,16 @@
       <HintPath>..\..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.4.1.4059, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
-      <HintPath>..\..\packages\xunit.assert.2.4.1-pre.build.4059\lib\netstandard2.0\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.assert.2.4.0\lib\netstandard2.0\xunit.assert.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.4.1.4059, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.4.1-pre.build.4059\lib\net452\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.4.0\lib\net452\xunit.core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.4.1.4059, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
-      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.1-pre.build.4059\lib\net452\xunit.execution.desktop.dll</HintPath>
+    <Reference Include="xunit.execution.desktop, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.0\lib\net452\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -84,12 +84,14 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets'))" />
     <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.targets'))" />
   </Target>
-  <Import Project="..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets')" />
+  <Import Project="..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.targets" Condition="Exists('..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.targets')" />
+  <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/tests/Range.Tests/Range.Tests.csproj
+++ b/tests/Range.Tests/Range.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props')" />
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props" Condition="Exists('..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -85,9 +85,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.1-pre.build.4059\build\net20\xunit.runner.visualstudio.props'))" />
     <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.props'))" />
     <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <Import Project="..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.1-pre.build.4059\build\xunit.core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/tests/Range.Tests/RangeTests.cs
+++ b/tests/Range.Tests/RangeTests.cs
@@ -224,8 +224,8 @@ namespace RimDev.Filter.Range.Tests
 
                 Assert.NotNull(range);
                 Assert.Equal(1, range.MinValue);
-                Assert.Equal(true, range.IsMinInclusive);
-                Assert.Equal(true, range.IsMaxInclusive);
+                Assert.True(range.IsMinInclusive);
+                Assert.True(range.IsMaxInclusive);
                 Assert.Equal(5, range.MaxValue);
             }
 
@@ -254,8 +254,8 @@ namespace RimDev.Filter.Range.Tests
 
                     Assert.NotNull(range);
                     Assert.Equal(1, range.MinValue);
-                    Assert.Equal(true, range.IsMinInclusive);
-                    Assert.Equal(true, range.IsMaxInclusive);
+                    Assert.True(range.IsMinInclusive);
+                    Assert.True(range.IsMaxInclusive);
                     Assert.Equal(5, range.MaxValue);
                 }
             }

--- a/tests/Range.Tests/packages.config
+++ b/tests/Range.Tests/packages.config
@@ -8,5 +8,5 @@
   <package id="xunit.extensibility.core" version="2.4.1-pre.build.4059" targetFramework="net462" />
   <package id="xunit.extensibility.execution" version="2.4.1-pre.build.4059" targetFramework="net462" />
   <package id="xunit.runner.msbuild" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.runner.visualstudio" version="2.4.1-pre.build.4059" targetFramework="net462" developmentDependency="true" />
+  <package id="xunit.runner.visualstudio" version="2.4.0" targetFramework="net462" developmentDependency="true" />
 </packages>

--- a/tests/Range.Tests/packages.config
+++ b/tests/Range.Tests/packages.config
@@ -1,10 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit" version="2.4.1-pre.build.4059" targetFramework="net462" />
+  <package id="xunit.abstractions" version="2.0.3" targetFramework="net462" />
+  <package id="xunit.analyzers" version="0.10.0" targetFramework="net462" />
+  <package id="xunit.assert" version="2.4.1-pre.build.4059" targetFramework="net462" />
+  <package id="xunit.core" version="2.4.1-pre.build.4059" targetFramework="net462" />
+  <package id="xunit.extensibility.core" version="2.4.1-pre.build.4059" targetFramework="net462" />
+  <package id="xunit.extensibility.execution" version="2.4.1-pre.build.4059" targetFramework="net462" />
   <package id="xunit.runner.msbuild" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.4.1-pre.build.4059" targetFramework="net462" developmentDependency="true" />
 </packages>

--- a/tests/Range.Tests/packages.config
+++ b/tests/Range.Tests/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.4.1-pre.build.4059" targetFramework="net462" />
+  <package id="xunit" version="2.4.0" targetFramework="net462" />
   <package id="xunit.abstractions" version="2.0.3" targetFramework="net462" />
   <package id="xunit.analyzers" version="0.10.0" targetFramework="net462" />
-  <package id="xunit.assert" version="2.4.1-pre.build.4059" targetFramework="net462" />
-  <package id="xunit.core" version="2.4.1-pre.build.4059" targetFramework="net462" />
-  <package id="xunit.extensibility.core" version="2.4.1-pre.build.4059" targetFramework="net462" />
-  <package id="xunit.extensibility.execution" version="2.4.1-pre.build.4059" targetFramework="net462" />
-  <package id="xunit.runner.msbuild" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.4.0" targetFramework="net462" />
+  <package id="xunit.core" version="2.4.0" targetFramework="net462" />
+  <package id="xunit.extensibility.core" version="2.4.0" targetFramework="net462" />
+  <package id="xunit.extensibility.execution" version="2.4.0" targetFramework="net462" />
+  <package id="xunit.runner.msbuild" version="2.4.0" targetFramework="net462" developmentDependency="true" />
   <package id="xunit.runner.visualstudio" version="2.4.0" targetFramework="net462" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
This work will allow us to easily support `Range` for NEST. It has methods that can determine if range values are "date ranges" or "numeric ranges". This can be used to construct the necessary queries against Elasticsearch.

This will be a major version number update as I've upgraded to NEST 6.3

#39 