### PR TITLE
Add support for NPoco

### DIFF
--- a/Filter.sln
+++ b/Filter.sln
@@ -19,6 +19,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Filter.Nest", "src\Filter.N
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Filter.Nest.Tests", "tests\Filter.Nest.Tests\Filter.Nest.Tests.csproj", "{2B4310E6-CD36-4BF7-9519-6CB6A7C8F2EA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Filter.NPoco", "src\Filter.NPoco\Filter.NPoco.csproj", "{36314F91-8877-4223-A1D2-0AF23B92A086}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Filter.NPoco.Tests", "tests\Filter.NPoco.Tests\Filter.NPoco.Tests.csproj", "{8D5E1963-14E4-4000-B492-BF24EB73C1AA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -49,6 +53,14 @@ Global
 		{2B4310E6-CD36-4BF7-9519-6CB6A7C8F2EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2B4310E6-CD36-4BF7-9519-6CB6A7C8F2EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2B4310E6-CD36-4BF7-9519-6CB6A7C8F2EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{36314F91-8877-4223-A1D2-0AF23B92A086}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36314F91-8877-4223-A1D2-0AF23B92A086}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36314F91-8877-4223-A1D2-0AF23B92A086}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36314F91-8877-4223-A1D2-0AF23B92A086}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D5E1963-14E4-4000-B492-BF24EB73C1AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D5E1963-14E4-4000-B492-BF24EB73C1AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D5E1963-14E4-4000-B492-BF24EB73C1AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D5E1963-14E4-4000-B492-BF24EB73C1AA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -57,6 +69,7 @@ Global
 		{A5283D85-C24D-467A-8B29-315320E5F80F} = {D26BB0C9-295E-4F30-90FA-532CAFA73A7D}
 		{1EC8770C-D078-45CA-B9CA-44FE3C66136D} = {86DCF3A9-55B1-48EB-B5E7-EF257718DA7D}
 		{2B4310E6-CD36-4BF7-9519-6CB6A7C8F2EA} = {D26BB0C9-295E-4F30-90FA-532CAFA73A7D}
+		{8D5E1963-14E4-4000-B492-BF24EB73C1AA} = {D26BB0C9-295E-4F30-90FA-532CAFA73A7D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {000D7362-598F-40B3-8D68-2436EA8FD8AC}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,9 @@
 cache:
   - packages -> **\packages.config
 
+before_build:
+  - ps: sqllocaldb c "v13.0" 13.0 -s
+
 build_script:
   - ps: ./build.ps1
 

--- a/src/Filter.NPoco/ExpressionHelper.cs
+++ b/src/Filter.NPoco/ExpressionHelper.cs
@@ -1,0 +1,32 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+
+namespace RimDev.Filter.NPoco
+{
+    /**
+     * Source: http://graemehill.ca/entity-framework-dynamic-queries-and-parameterization/
+     */
+    internal static class ExpressionHelper
+    {
+        [SuppressMessage("ReSharper", "UnusedMember.Local", Justification = "This method is invoked dynamically.")]
+        public static MemberExpression WrappedConstant<TValue>(TValue value)
+        {
+            var wrapper = new WrappedObj<TValue>(value);
+            return Expression.Field(
+                Expression.Constant(wrapper),
+                typeof(WrappedObj<TValue>).GetField("Value"));
+        }
+
+        [SuppressMessage("ReSharper", "MemberCanBePrivate.Local")]
+        private struct WrappedObj<TValue>
+        {
+            [SuppressMessage("ReSharper", "NotAccessedField.Local", Justification = "This member is dynamically accessed.")]
+            public readonly TValue Value;
+
+            public WrappedObj(TValue value)
+            {
+                Value = value;
+            }
+        }
+    }
+}

--- a/src/Filter.NPoco/Filter.NPoco.csproj
+++ b/src/Filter.NPoco/Filter.NPoco.csproj
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{36314F91-8877-4223-A1D2-0AF23B92A086}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>RimDev.Filter.NPoco</RootNamespace>
+    <AssemblyName>RimDev.Filter.NPoco</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="NPoco, Version=3.9.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NPoco.3.9.4\lib\net45\NPoco.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ExpressionHelper.cs" />
+    <Compile Include="FilterBuilder.cs" />
+    <Compile Include="IDatabaseExtensions.cs" />
+    <Compile Include="IQueryProviderExtensions.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SqlExpressionExtensions.cs" />
+    <Compile Include="SqlBuilderExtensions.cs" />
+    <Compile Include="TypeSystem.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Filter\Filter.csproj">
+      <Project>{78ea264d-1eab-4d55-bad1-71f2d3de1a2a}</Project>
+      <Name>Filter</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/Filter.NPoco/FilterBuilder.cs
+++ b/src/Filter.NPoco/FilterBuilder.cs
@@ -1,0 +1,31 @@
+﻿using NPoco;
+using System.Collections.Generic;
+
+namespace RimDev.Filter.NPoco
+{
+    public class FilterBuilder<T>
+    {
+        public FilterBuilder(
+            IDatabase database,
+            string sql,
+            params object[] parameters)
+        {
+            this.database = database;
+            this.sql = sql;
+            this.parameters = parameters;
+        }
+
+        private readonly IDatabase database;
+        private readonly string sql;
+        private readonly object[] parameters;
+
+        public List<T> Fetch(object filter)
+        {
+            var template = new SqlBuilder()
+                .Filter<T>(database, filter)
+                .AddTemplate(sql, parameters);
+
+            return database.Fetch<T>(template);
+        }
+    }
+}

--- a/src/Filter.NPoco/IDatabaseExtensions.cs
+++ b/src/Filter.NPoco/IDatabaseExtensions.cs
@@ -1,0 +1,15 @@
+﻿using NPoco;
+
+namespace RimDev.Filter.NPoco
+{
+    public static class IDatabaseExtensions
+    {
+        public static FilterBuilder<T> With<T>(
+            this IDatabase database,
+            string template,
+            params object[] parameters)
+        {
+            return new FilterBuilder<T>(database, template, parameters);
+        }
+    }
+}

--- a/src/Filter.NPoco/IQueryProviderExtensions.cs
+++ b/src/Filter.NPoco/IQueryProviderExtensions.cs
@@ -1,0 +1,284 @@
+﻿using NPoco.Linq;
+using RimDev.Filter.Range.Generic;
+using System;
+using System.Collections;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace RimDev.Filter.NPoco
+{
+    public static class IQueryProviderExtensions
+    {
+        public static IQueryProvider<T> Filter<T>(
+            this IQueryProvider<T> value,
+            object filter)
+        {
+            if (filter == null)
+            {
+                return value;
+            }
+
+            var validValueProperties = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(x => x.CanRead)
+                .ToDictionary(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase);
+
+            var filterProperties = filter.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(x => x.CanRead);
+
+            var queryableValue = value;
+            foreach (var filterProperty in filterProperties)
+            {
+                PropertyInfo validValueProperty;
+                validValueProperties.TryGetValue(filterProperty.Name, out validValueProperty);
+
+                var filterPropertyValue = filterProperty.GetValue(filter, null);
+                if (validValueProperty != null && filterPropertyValue != null)
+                {
+                    var validValuePropertyName = validValueProperty.Name;
+
+                    if (typeof(IEnumerable).IsAssignableFrom(filterProperty.PropertyType) &&
+                        filterProperty.PropertyType != typeof(string))
+                    {
+                        object firstItem = null;
+                        if (typeof(ICollection).IsAssignableFrom(filterProperty.PropertyType) &&
+                            ((ICollection)filterPropertyValue).Count == 1)
+                        {
+                            Array array;
+                            if (filterProperty.PropertyType.IsArray)
+                            {
+                                array = (Array)filterPropertyValue;
+                            }
+                            else
+                            {
+                                array = new object[1];
+                                ((ICollection)filterPropertyValue).CopyTo(array, 0);
+                            }
+
+                            firstItem = array.GetValue(0);
+                            if (firstItem != null)
+                            {
+                                var underlyingType = Nullable.GetUnderlyingType(
+                                    TypeSystem.GetElementType(validValueProperty.PropertyType)) ?? validValueProperty.PropertyType;
+
+                                queryableValue = queryableValue.Where(property: validValuePropertyName, valueType: underlyingType, value: firstItem);
+                            }
+                        }
+
+                        if (firstItem == null)
+                            queryableValue = queryableValue.Contains(validValuePropertyName, (IEnumerable)filterPropertyValue);
+                    }
+                    else if (filterProperty.PropertyType.IsGenericType &&
+                        typeof(IRange<>).IsAssignableFrom(filterProperty.PropertyType.GetGenericTypeDefinition()) ||
+                        filterProperty.PropertyType.GetInterfaces()
+                        .Where(x => x.IsGenericType)
+                        .Any(x => x.GetGenericTypeDefinition() == typeof(IRange<>)))
+                    {
+                        var genericTypeArgument = filterPropertyValue.GetType().GenericTypeArguments.First();
+
+                        if (genericTypeArgument == typeof(byte))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<byte>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(char))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<char>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(DateTime))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<DateTime>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(DateTimeOffset))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<DateTimeOffset>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(decimal))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<decimal>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(double))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<double>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(float))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<float>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(int))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<int>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(long))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<long>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(sbyte))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<sbyte>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(short))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<short>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(uint))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<uint>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(ulong))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<ulong>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(ushort))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<ushort>)filterPropertyValue);
+                        }
+                    }
+                    else
+                    {
+                        try
+                        {
+                            var propertyType = Nullable.GetUnderlyingType(validValueProperty.PropertyType) ??
+                                               validValueProperty.PropertyType;
+
+                            queryableValue = queryableValue.Where(property: validValuePropertyName, valueType: propertyType, value: filterPropertyValue);
+                        }
+                        catch (Exception) { }
+                    }
+                }
+            }
+
+            return queryableValue;
+        }
+
+        private static IQueryProvider<T> Contains<T>(
+            this IQueryProvider<T> query,
+            string property,
+            IEnumerable values)
+        {
+            if (values == null || !values.Cast<object>().Any())
+            {
+                return query;
+            }
+
+            var parameterExpression = Expression.Parameter(typeof(T), "x");
+            var propertyExpression = (Expression)Expression.Property(parameterExpression, property);
+            var constantExpression = Expression.Constant(values);
+            var propertyExpressionIsNullable = propertyExpression.Type.IsGenericType
+                                                && propertyExpression.Type.GetGenericTypeDefinition() == typeof(Nullable<>)
+                                                && constantExpression.Type.GetElementType() != propertyExpression.Type;
+
+            if (propertyExpressionIsNullable)
+            {
+                propertyExpression = Expression.Property(propertyExpression, "Value");
+            }
+
+            Expression callExpression = Expression.Call(
+                typeof(Enumerable),
+                "Contains",
+                new[] { propertyExpression.Type },
+                constantExpression,
+                propertyExpression);
+
+            if (propertyExpressionIsNullable)
+            {
+                var nullablePropertyExpression = Expression.Property(parameterExpression, property);
+                var notEqual = Expression.NotEqual(nullablePropertyExpression, Expression.Constant(null, nullablePropertyExpression.Type));
+                callExpression = Expression.AndAlso(notEqual, callExpression);
+            }
+
+            var lambda = Expression.Lambda<Func<T, bool>>(callExpression, parameterExpression);
+
+            return query.Where(lambda);
+        }
+
+        private static IQueryProvider<T> Where<T>(
+            this IQueryProvider<T> query,
+            string property,
+            Type valueType,
+            object value)
+        {
+            var parameterExpression = Expression.Parameter(typeof(T), "x");
+            var propertyExpression = Expression.Property(parameterExpression, property);
+
+            var method = typeof(ExpressionHelper).GetMethod("WrappedConstant");
+            var genericMethod = method.MakeGenericMethod(valueType);
+
+            var constantExpression = (MemberExpression)genericMethod.Invoke(null, new[] { value });
+            var comparandExpression = Nullable.GetUnderlyingType(propertyExpression.Type) != null
+                ? Expression.Convert(constantExpression, propertyExpression.Type)
+                : (Expression)constantExpression;
+
+            var equalExpression = Expression.Equal(propertyExpression, comparandExpression);
+            var lambdaExpression = Expression.Lambda<Func<T, bool>>(equalExpression, parameterExpression);
+
+            return query.Where(lambdaExpression);
+        }
+
+        private static IQueryProvider<T> Range<T, TRange>(
+            this IQueryProvider<T> query,
+            string property,
+            IRange<TRange> range)
+            where TRange : struct
+        {
+            var parameterExpression = Expression.Parameter(typeof(T), "x");
+            var propertyExpression = Expression.Property(parameterExpression, property);
+
+            Expression minConstantExpression = null;
+
+            if (range.MinValue.HasValue)
+            {
+                var minValueExpression = Expression.Constant(range.MinValue);
+                minConstantExpression = minValueExpression.Type != propertyExpression.Type
+                    ? Expression.Convert(minValueExpression, propertyExpression.Type)
+                    : (Expression)minValueExpression;
+            }
+
+            BinaryExpression minGreaterExpression = null;
+
+            if (minConstantExpression != null)
+            {
+                minGreaterExpression = range.IsMinInclusive
+                ? Expression.GreaterThanOrEqual(propertyExpression, minConstantExpression)
+                : Expression.GreaterThan(propertyExpression, minConstantExpression);
+            }
+
+            Expression maxConstantExpression = null;
+
+            if (range.MaxValue.HasValue)
+            {
+                var maxValueExpression = Expression.Constant(range.MaxValue);
+                maxConstantExpression = maxValueExpression.Type != propertyExpression.Type
+                    ? Expression.Convert(maxValueExpression, propertyExpression.Type)
+                    : (Expression)maxValueExpression;
+            }
+
+            BinaryExpression maxLessExpression = null;
+
+            if (maxConstantExpression != null)
+            {
+                maxLessExpression = range.IsMaxInclusive
+                ? Expression.LessThanOrEqual(propertyExpression, maxConstantExpression)
+                : Expression.LessThan(propertyExpression, maxConstantExpression);
+            }
+
+            Expression logicExpression;
+
+            if (minGreaterExpression != null && maxLessExpression != null)
+            {
+                logicExpression = Expression.AndAlso(minGreaterExpression, maxLessExpression);
+            }
+            else if (minGreaterExpression != null)
+            {
+                logicExpression = minGreaterExpression;
+            }
+            else
+            {
+                logicExpression = maxLessExpression;
+            }
+
+            var lambdaExpression = Expression.Lambda<Func<T, bool>>(logicExpression, parameterExpression);
+
+            return query.Where(lambdaExpression);
+        }
+    }
+}

--- a/src/Filter.NPoco/Properties/AssemblyInfo.cs
+++ b/src/Filter.NPoco/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Filter.NPoco")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Filter.NPoco")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("36314f91-8877-4223-a1d2-0af23b92a086")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Filter.NPoco/SqlBuilderExtensions.cs
+++ b/src/Filter.NPoco/SqlBuilderExtensions.cs
@@ -1,0 +1,35 @@
+﻿using NPoco;
+
+namespace RimDev.Filter.NPoco
+{
+    public static class SqlBuilderExtensions
+    {
+        public static SqlBuilder Filter<T>(
+            this SqlBuilder value,
+            IDatabase database,
+            object filter)
+        {
+            var pocoData = database.PocoDataFactory.ForType(typeof(T));
+            var sqlExpression = database.DatabaseType.ExpressionVisitor<T>(database, pocoData, false);
+
+            sqlExpression = sqlExpression.Filter(filter);
+
+            // The `where`-clause is ultimately added by the caller's SQL via SqlBuilder.AddTemplate.
+            var cleansedWhereStatement = sqlExpression.Context.ToWhereStatement()
+                ?.Replace("WHERE ", string.Empty)
+                ?.Trim();
+
+            if (!string.IsNullOrEmpty(cleansedWhereStatement))
+            {
+                var sql = new Sql(
+                    true,
+                    cleansedWhereStatement,
+                    sqlExpression.Context.Params);
+
+                value = value.Where(sql.SQL, sql.Arguments);
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/Filter.NPoco/SqlExpressionExtensions.cs
+++ b/src/Filter.NPoco/SqlExpressionExtensions.cs
@@ -1,0 +1,285 @@
+﻿using NPoco.Expressions;
+using RimDev.Filter.Generic;
+using RimDev.Filter.Range.Generic;
+using System;
+using System.Collections;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace RimDev.Filter.NPoco
+{
+    internal static class SqlExpressionExtensions
+    {
+        public static SqlExpression<T> Filter<T>(
+            this SqlExpression<T> value,
+            object filter)
+        {
+            if (filter == null)
+            {
+                return value;
+            }
+
+            var validValueProperties = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(x => x.CanRead)
+                .ToDictionary(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase);
+
+            var filterProperties = filter.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(x => x.CanRead);
+
+            var queryableValue = value;
+            foreach (var filterProperty in filterProperties)
+            {
+                PropertyInfo validValueProperty;
+                validValueProperties.TryGetValue(filterProperty.Name, out validValueProperty);
+
+                var filterPropertyValue = filterProperty.GetValue(filter, null);
+                if (validValueProperty != null && filterPropertyValue != null)
+                {
+                    var validValuePropertyName = validValueProperty.Name;
+
+                    if (typeof(IEnumerable).IsAssignableFrom(filterProperty.PropertyType) &&
+                        filterProperty.PropertyType != typeof(string))
+                    {
+                        object firstItem = null;
+                        if (typeof(ICollection).IsAssignableFrom(filterProperty.PropertyType) &&
+                            ((ICollection)filterPropertyValue).Count == 1)
+                        {
+                            Array array;
+                            if (filterProperty.PropertyType.IsArray)
+                            {
+                                array = (Array)filterPropertyValue;
+                            }
+                            else
+                            {
+                                array = new object[1];
+                                ((ICollection)filterPropertyValue).CopyTo(array, 0);
+                            }
+
+                            firstItem = array.GetValue(0);
+                            if (firstItem != null)
+                            {
+                                var underlyingType = Nullable.GetUnderlyingType(
+                                    TypeSystem.GetElementType(validValueProperty.PropertyType)) ?? validValueProperty.PropertyType;
+
+                                queryableValue = queryableValue.Where(property: validValuePropertyName, valueType: underlyingType, value: firstItem);
+                            }
+                        }
+
+                        if (firstItem == null)
+                            queryableValue = queryableValue.Contains(validValuePropertyName, (IEnumerable)filterPropertyValue);
+                    }
+                    else if (filterProperty.PropertyType.IsGenericType &&
+                        typeof(IRange<>).IsAssignableFrom(filterProperty.PropertyType.GetGenericTypeDefinition()) ||
+                        filterProperty.PropertyType.GetInterfaces()
+                        .Where(x => x.IsGenericType)
+                        .Any(x => x.GetGenericTypeDefinition() == typeof(IRange<>)))
+                    {
+                        var genericTypeArgument = filterPropertyValue.GetType().GenericTypeArguments.First();
+
+                        if (genericTypeArgument == typeof(byte))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<byte>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(char))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<char>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(DateTime))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<DateTime>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(DateTimeOffset))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<DateTimeOffset>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(decimal))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<decimal>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(double))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<double>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(float))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<float>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(int))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<int>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(long))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<long>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(sbyte))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<sbyte>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(short))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<short>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(uint))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<uint>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(ulong))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<ulong>)filterPropertyValue);
+                        }
+                        else if (genericTypeArgument == typeof(ushort))
+                        {
+                            queryableValue = queryableValue.Range(validValuePropertyName, (IRange<ushort>)filterPropertyValue);
+                        }
+                    }
+                    else
+                    {
+                        try
+                        {
+                            var propertyType = Nullable.GetUnderlyingType(validValueProperty.PropertyType) ??
+                                               validValueProperty.PropertyType;
+
+                            queryableValue = queryableValue.Where(property: validValuePropertyName, valueType: propertyType, value: filterPropertyValue);
+                        }
+                        catch (Exception) { }
+                    }
+                }
+            }
+
+            return queryableValue;
+        }
+
+        private static SqlExpression<T> Contains<T>(
+            this SqlExpression<T> query,
+            string property,
+            IEnumerable values)
+        {
+            if (values == null || !values.Cast<object>().Any())
+            {
+                return query;
+            }
+
+            var parameterExpression = Expression.Parameter(typeof(T), "x");
+            var propertyExpression = (Expression)Expression.Property(parameterExpression, property);
+            var constantExpression = Expression.Constant(values);
+            var propertyExpressionIsNullable = propertyExpression.Type.IsGenericType
+                                                && propertyExpression.Type.GetGenericTypeDefinition() == typeof(Nullable<>)
+                                                && constantExpression.Type.GetElementType() != propertyExpression.Type;
+
+            if (propertyExpressionIsNullable)
+            {
+                propertyExpression = Expression.Property(propertyExpression, "Value");
+            }
+
+            Expression callExpression = Expression.Call(
+                typeof(Enumerable),
+                "Contains",
+                new[] { propertyExpression.Type },
+                constantExpression,
+                propertyExpression);
+
+            if (propertyExpressionIsNullable)
+            {
+                var nullablePropertyExpression = Expression.Property(parameterExpression, property);
+                var notEqual = Expression.NotEqual(nullablePropertyExpression, Expression.Constant(null, nullablePropertyExpression.Type));
+                callExpression = Expression.AndAlso(notEqual, callExpression);
+            }
+
+            var lambda = Expression.Lambda<Func<T, bool>>(callExpression, parameterExpression);
+
+            return query.Where(lambda);
+        }
+
+        private static SqlExpression<T> Where<T>(
+            this SqlExpression<T> query,
+            string property,
+            Type valueType,
+            object value)
+        {
+            var parameterExpression = Expression.Parameter(typeof(T), "x");
+            var propertyExpression = Expression.Property(parameterExpression, property);
+
+            var method = typeof(ExpressionHelper).GetMethod("WrappedConstant");
+            var genericMethod = method.MakeGenericMethod(valueType);
+
+            var constantExpression = (MemberExpression)genericMethod.Invoke(null, new[] { value });
+            var comparandExpression = Nullable.GetUnderlyingType(propertyExpression.Type) != null
+                ? Expression.Convert(constantExpression, propertyExpression.Type)
+                : (Expression)constantExpression;
+
+            var equalExpression = Expression.Equal(propertyExpression, comparandExpression);
+            var lambdaExpression = Expression.Lambda<Func<T, bool>>(equalExpression, parameterExpression);
+
+            return query.Where(lambdaExpression);
+        }
+
+        private static SqlExpression<T> Range<T, TRange>(
+            this SqlExpression<T> query,
+            string property,
+            IRange<TRange> range)
+            where TRange : struct
+        {
+            var parameterExpression = Expression.Parameter(typeof(T), "x");
+            var propertyExpression = Expression.Property(parameterExpression, property);
+
+            Expression minConstantExpression = null;
+
+            if (range.MinValue.HasValue)
+            {
+                var minValueExpression = Expression.Constant(range.MinValue);
+                minConstantExpression = minValueExpression.Type != propertyExpression.Type
+                    ? Expression.Convert(minValueExpression, propertyExpression.Type)
+                    : (Expression)minValueExpression;
+            }
+
+            BinaryExpression minGreaterExpression = null;
+
+            if (minConstantExpression != null)
+            {
+                minGreaterExpression = range.IsMinInclusive
+                ? Expression.GreaterThanOrEqual(propertyExpression, minConstantExpression)
+                : Expression.GreaterThan(propertyExpression, minConstantExpression);
+            }
+
+            Expression maxConstantExpression = null;
+
+            if (range.MaxValue.HasValue)
+            {
+                var maxValueExpression = Expression.Constant(range.MaxValue);
+                maxConstantExpression = maxValueExpression.Type != propertyExpression.Type
+                    ? Expression.Convert(maxValueExpression, propertyExpression.Type)
+                    : (Expression)maxValueExpression;
+            }
+
+            BinaryExpression maxLessExpression = null;
+
+            if (maxConstantExpression != null)
+            {
+                maxLessExpression = range.IsMaxInclusive
+                ? Expression.LessThanOrEqual(propertyExpression, maxConstantExpression)
+                : Expression.LessThan(propertyExpression, maxConstantExpression);
+            }
+
+            Expression logicExpression;
+
+            if (minGreaterExpression != null && maxLessExpression != null)
+            {
+                logicExpression = Expression.AndAlso(minGreaterExpression, maxLessExpression);
+            }
+            else if (minGreaterExpression != null)
+            {
+                logicExpression = minGreaterExpression;
+            }
+            else
+            {
+                logicExpression = maxLessExpression;
+            }
+
+            var lambdaExpression = Expression.Lambda<Func<T, bool>>(logicExpression, parameterExpression);
+
+            return query.Where(lambdaExpression);
+        }
+    }
+}

--- a/src/Filter.NPoco/TypeSystem.cs
+++ b/src/Filter.NPoco/TypeSystem.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace RimDev.Filter.NPoco
+{
+    /**
+     * The guy who wrote LINQ wrote the code below. LINQ seems to be doing ok, so I trust it.
+     * http://blogs.msdn.com/b/mattwar/archive/2007/07/30/linq-building-an-iqueryable-provider-part-i.aspx
+     */
+    internal static class TypeSystem
+    {
+        internal static Type GetElementType(Type seqType)
+        {
+            var ienum = FindIEnumerable(seqType);
+            return ienum == null ? seqType : ienum.GetGenericArguments()[0];
+        }
+
+        private static Type FindIEnumerable(Type seqType)
+        {
+            if (seqType == null || seqType == typeof(string))
+                return null;
+
+            if (seqType.IsArray)
+                return typeof(IEnumerable<>).MakeGenericType(seqType.GetElementType());
+
+            if (seqType.IsGenericType)
+            {
+                foreach (var arg in seqType.GetGenericArguments())
+                {
+                    var ienum = typeof(IEnumerable<>).MakeGenericType(arg);
+                    if (ienum.IsAssignableFrom(seqType))
+                    {
+                        return ienum;
+                    }
+                }
+            }
+
+            var ifaces = seqType.GetInterfaces();
+            if (ifaces.Length > 0)
+            {
+                foreach (var iface in ifaces)
+                {
+                    var ienum = FindIEnumerable(iface);
+                    if (ienum != null) return ienum;
+                }
+            }
+
+            if (seqType.BaseType != null && seqType.BaseType != typeof(object))
+            {
+                return FindIEnumerable(seqType.BaseType);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Filter.NPoco/packages.config
+++ b/src/Filter.NPoco/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NPoco" version="3.9.4" targetFramework="net462" />
+</packages>

--- a/tests/Filter.NPoco.Tests/DatabaseFixture.cs
+++ b/tests/Filter.NPoco.Tests/DatabaseFixture.cs
@@ -1,0 +1,89 @@
+﻿using NPoco;
+using RimDev.Automation.Sql;
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+
+namespace Filter.NPoco.Tests
+{
+    public class DatabaseFixture : IDisposable
+    {
+        public DatabaseFixture()
+        {
+            string dbSuffix = string.Empty;
+
+            do
+            {
+                dbSuffix = Guid.NewGuid().ToString("N");
+            } while (dbSuffixes.Contains(dbSuffix));
+
+            dbSuffixes.Add(dbSuffix);
+
+            localDb = new LocalDb(version: "v13.0", databaseSuffixGenerator: () => dbSuffix);
+
+            using (var connection = new SqlConnection(localDb.ConnectionString))
+            {
+                connection.Open();
+
+                using (var command = new SqlCommand())
+                {
+                    command.Connection = connection;
+                    command.CommandText = @"
+create table Person(
+    Id int identity not null,
+    DONOTUSE nvarchar(50),
+    FavoriteDate datetime,
+    FavoriteDateTimeOffset datetimeoffset,
+    FavoriteLetter nchar(1),
+    FavoriteNumber int,
+    FirstName nvarchar(50),
+    LastName nvarchar(50),
+    Rating decimal(5,2) null
+)";
+
+                    command.ExecuteNonQuery();
+                }
+            }
+
+            Database = new Database(localDb.ConnectionString, DatabaseType.SqlServer2008);
+
+            Database.InsertBulk(people);
+        }
+
+        public readonly IDatabase Database;
+
+        private static List<string> dbSuffixes = new List<string>();
+
+        private readonly IEnumerable<Person> people = new List<Person>()
+        {
+            new Person()
+            {
+                FavoriteDate = DateTime.Parse("2000-01-01"),
+                FavoriteDateTimeOffset = DateTimeOffset.Parse("2010-01-01"),
+                FavoriteLetter = 'a',
+                FavoriteNumber = 5,
+                FirstName = "John",
+                LastName = "Doe",
+                Rating = null
+            },
+            new Person()
+            {
+                FavoriteDate = DateTime.Parse("2000-01-02"),
+                FavoriteDateTimeOffset = DateTimeOffset.Parse("2010-01-02"),
+                FavoriteLetter = 'b',
+                FavoriteNumber = 10,
+                FirstName = "Tim",
+                LastName = "Smith",
+                Rating = 4.5m
+            },
+        };
+
+        private LocalDb localDb;
+
+        public void Dispose()
+        {
+            localDb.Dispose();
+            Database.Dispose();
+        }
+    }
+}

--- a/tests/Filter.NPoco.Tests/Filter.NPoco.Tests.csproj
+++ b/tests/Filter.NPoco.Tests/Filter.NPoco.Tests.csproj
@@ -73,6 +73,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DatabaseFixture.cs" />
+    <Compile Include="Person.cs" />
     <Compile Include="SqlBuilderExtensionsTests.cs" />
     <Compile Include="IQueryProviderExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/tests/Filter.NPoco.Tests/Filter.NPoco.Tests.csproj
+++ b/tests/Filter.NPoco.Tests/Filter.NPoco.Tests.csproj
@@ -1,0 +1,109 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.props" Condition="Exists('..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.props')" />
+  <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8D5E1963-14E4-4000-B492-BF24EB73C1AA}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>RimDev.Filter.NPoco.Tests</RootNamespace>
+    <AssemblyName>RimDev.Filter.NPoco.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="NPoco, Version=3.9.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NPoco.3.9.4\lib\net45\NPoco.dll</HintPath>
+    </Reference>
+    <Reference Include="RimDev.Automation.Sql, Version=0.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\RimDev.Automation.Sql.0.3.0\lib\net45\RimDev.Automation.Sql.dll</HintPath>
+    </Reference>
+    <Reference Include="RimDev.Sandbox, Version=0.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\RimDev.Sandbox.0.2.2\lib\net45\RimDev.Sandbox.dll</HintPath>
+    </Reference>
+    <Reference Include="RimDev.Sandbox.LocalDb, Version=0.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\RimDev.Sandbox.LocalDb.0.2.2\lib\net45\RimDev.Sandbox.LocalDb.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.2\lib\net35\xunit.abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.4.0\lib\netstandard2.0\xunit.assert.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.4.0\lib\net452\xunit.core.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.0\lib\net452\xunit.execution.desktop.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="SqlBuilderExtensionsTests.cs" />
+    <Compile Include="IQueryProviderExtensionsTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Filter.NPoco\Filter.NPoco.csproj">
+      <Project>{36314f91-8877-4223-a1d2-0af23b92a086}</Project>
+      <Name>Filter.NPoco</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Filter\Filter.csproj">
+      <Project>{78ea264d-1eab-4d55-bad1-71f2d3de1a2a}</Project>
+      <Name>Filter</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.10.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
+  <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" />
+  <Import Project="..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.targets" Condition="Exists('..\..\packages\xunit.runner.msbuild.2.4.0\build\net452\xunit.runner.msbuild.targets')" />
+</Project>

--- a/tests/Filter.NPoco.Tests/IQueryProviderExtensionsTests.cs
+++ b/tests/Filter.NPoco.Tests/IQueryProviderExtensionsTests.cs
@@ -1,0 +1,500 @@
+﻿using NPoco;
+using RimDev.Automation.Sql;
+using RimDev.Filter.NPoco;
+using RimDev.Filter.Range.Generic;
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using Xunit;
+
+namespace RimDev.Filter.Tests
+{
+    public class IQueryProviderExtensionsTests
+    {
+        public class Filter : IQueryProviderExtensionsTests, IDisposable
+        {
+            public Filter()
+            {
+                localDb = new LocalDb(version: "v13.0");
+
+                using (var connection = new SqlConnection(localDb.ConnectionString))
+                {
+                    connection.Open();
+
+                    using (var command = new SqlCommand())
+                    {
+                        command.Connection = connection;
+                        command.CommandText = @"
+create table Person(
+    Id int identity not null,
+    FavoriteDate datetime,
+    FavoriteDateTimeOffset datetimeoffset,
+    FavoriteLetter nchar(1),
+    FavoriteNumber int,
+    FirstName nvarchar(50),
+    LastName nvarchar(50),
+    Rating decimal(5,2) null
+)";
+
+                        command.ExecuteNonQuery();
+                    }
+                }
+
+                Database = new Database(localDb.ConnectionString, DatabaseType.SqlServer2008);
+
+                Database.InsertBulk(people);
+            }
+
+            [TableName("Person")]
+            [PrimaryKey(nameof(Id))]
+            public class Person
+            {
+                public int Id { get; set; }
+                public DateTime FavoriteDate { get; set; }
+                public DateTimeOffset FavoriteDateTimeOffset { get; set; }
+                public char FavoriteLetter { get; set; }
+                public int FavoriteNumber { get; set; }
+                public string FirstName { get; set; }
+                public string LastName { get; set; }
+                public decimal? Rating { get; set; }
+            }
+
+            protected readonly IDatabase Database;
+
+            private readonly IEnumerable<Person> people = new List<Person>()
+            {
+                new Person()
+                {
+                    FavoriteDate = DateTime.Parse("2000-01-01"),
+                    FavoriteDateTimeOffset = DateTimeOffset.Parse("2010-01-01"),
+                    FavoriteLetter = 'a',
+                    FavoriteNumber = 5,
+                    FirstName = "John",
+                    LastName = "Doe"
+                },
+                new Person()
+                {
+                    FavoriteDate = DateTime.Parse("2000-01-02"),
+                    FavoriteDateTimeOffset = DateTimeOffset.Parse("2010-01-02"),
+                    FavoriteLetter = 'b',
+                    FavoriteNumber = 10,
+                    FirstName = "Tim",
+                    LastName = "Smith",
+                    Rating = 4.5m
+                },
+            };
+
+            private LocalDb localDb;
+
+            public void Dispose()
+            {
+                localDb.Dispose();
+                Database.Dispose();
+            }
+        }
+
+        public class ConstantFilters : Filter
+        {
+            [Fact]
+            public void Should_filter_when_property_types_match_as_constant_string()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FirstName = "John"
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(1, @return.Count());
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_constant_integer()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FavoriteNumber = 5
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(1, @return.Count());
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_multiple_properties()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FirstName = "John",
+                    FavoriteNumber = 0
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(0, @return.Count());
+            }
+
+            [Fact]
+            public void Should_not_throw_if_filter_does_not_contain_valid_properties()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    DOESNOTEXIST = ""
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(2, @return.Count());
+            }
+
+            [Fact]
+            public void Should_not_throw_if_filter_constant_type_does_not_match()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FirstName = 1
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(2, @return.Count());
+            }
+        }
+
+        public class EnumerableFilters : Filter
+        {
+            [Fact]
+            public void Should_bypass_filter_when_empty_collection()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FirstName = new string[] { }
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(2, @return.Count());
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_enumerable_string()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FirstName = new[] { "John" }
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(1, @return.Count());
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_enumerable_integer()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FavoriteNumber = new[] { 5 }
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(1, @return.Count());
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_be_able_to_handle_nullable_destination_and_primitive_filter()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    Rating = new[] { 4.5m }
+                });
+
+                Assert.Equal(1, @return.Count());
+            }
+
+            [Fact]
+            public void Should_be_able_to_handle_nullable_destination_and_nullable_primitive_filter_as_collection()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    Rating = new decimal?[] { 4.5m }
+                });
+
+                Assert.Equal(1, @return.Count());
+            }
+
+            [Fact]
+            public void Should_be_able_to_handle_nullable_destination_and_nullable_primitive_filter()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    Rating = new decimal?(4.5m)
+                });
+
+                Assert.Equal(1, @return.Count());
+            }
+
+            [Fact]
+            public void Should_be_able_to_handle_nullable_source()
+            {
+                var people = Database.Query<Person>().ToList();
+                people.ForEach(x => x.Rating = null);
+
+                foreach (var person in people)
+                {
+                    Database.Update(person);
+                }
+
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    Rating = new decimal?[] { 4.5m }
+                }).ToList();
+
+                Assert.Empty(@return);
+            }
+        }
+
+        public class RangeFilters : Filter
+        {
+            [Theory,
+            InlineData("(,5]"),
+            InlineData("(-∞,5]")]
+            public void Should_filter_open_ended_lower_bound(string value)
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FavoriteNumber = Range.Range.FromString<int>(value)
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(1, @return.Count());
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Theory,
+            InlineData("(5,]"),
+            InlineData("(5,+∞)")]
+            public void Should_filter_open_ended_upper_bound(string value)
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FavoriteNumber = Range.Range.FromString<int>(value)
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(1, @return.Count());
+                Assert.Equal("Tim", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_for_concrete_range()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FavoriteNumber = new Range<int>()
+                    {
+                        MinValue = 5,
+                        MaxValue = 5,
+                        IsMinInclusive = true,
+                        IsMaxInclusive = true
+                    }
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(1, @return.Count());
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_byte()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FavoriteNumber = Range.Range.FromString<byte>("[5,5]")
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(1, @return.Count());
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_char()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FavoriteLetter = Range.Range.FromString<char>("[a,b)")
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(1, @return.Count());
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_datetime()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FavoriteDate = Range.Range.FromString<DateTime>("[2000-01-01,2000-01-02)")
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(1, @return.Count());
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_datetimeoffset()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FavoriteDateTimeOffset = Range.Range.FromString<DateTimeOffset>("[2010-01-01,2010-01-02)")
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(1, @return.Count());
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_decimal()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FavoriteNumber = Range.Range.FromString<decimal>("[4.5,5]")
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(1, @return.Count());
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_double()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FavoriteNumber = Range.Range.FromString<double>("[4.5,5]")
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(1, @return.Count());
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_float()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FavoriteNumber = Range.Range.FromString<float>("[4.5,5]")
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(1, @return.Count());
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_int()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FavoriteNumber = Range.Range.FromString<int>("[5,5]")
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(1, @return.Count());
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_long()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FavoriteNumber = Range.Range.FromString<long>("[5,5]")
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(1, @return.Count());
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_sbyte()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FavoriteNumber = Range.Range.FromString<sbyte>("[5,5]")
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(1, @return.Count());
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_short()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FavoriteNumber = Range.Range.FromString<short>("[5,5]")
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(1, @return.Count());
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_uint()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FavoriteNumber = Range.Range.FromString<uint>("[5,5]")
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(1, @return.Count());
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_ulong()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FavoriteNumber = Range.Range.FromString<ulong>("[5,5]")
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(1, @return.Count());
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_ushort()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    FavoriteNumber = Range.Range.FromString<ushort>("[5,5]")
+                });
+
+                Assert.NotNull(@return);
+                Assert.Equal(1, @return.Count());
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_be_able_to_handle_nullable_source()
+            {
+                var @return = Database.Query<Person>().Filter(new
+                {
+                    Rating = (Range<decimal>)"[4.5,5.0]"
+                });
+
+                Assert.Equal(1, @return.Count());
+            }
+        }
+    }
+}

--- a/tests/Filter.NPoco.Tests/IQueryProviderExtensionsTests.cs
+++ b/tests/Filter.NPoco.Tests/IQueryProviderExtensionsTests.cs
@@ -1,104 +1,33 @@
-﻿using NPoco;
-using RimDev.Automation.Sql;
-using RimDev.Filter.NPoco;
+﻿using RimDev.Filter.NPoco;
+using RimDev.Filter.Range;
 using RimDev.Filter.Range.Generic;
 using System;
-using System.Collections.Generic;
-using System.Data.SqlClient;
 using Xunit;
 
-namespace RimDev.Filter.Tests
+namespace Filter.NPoco.Tests
 {
     public class IQueryProviderExtensionsTests
     {
-        public class Filter : IQueryProviderExtensionsTests, IDisposable
+        public abstract class Filter : IQueryProviderExtensionsTests, IClassFixture<DatabaseFixture>
         {
-            public Filter()
+            public Filter(DatabaseFixture fixture)
             {
-                localDb = new LocalDb(version: "v13.0");
-
-                using (var connection = new SqlConnection(localDb.ConnectionString))
-                {
-                    connection.Open();
-
-                    using (var command = new SqlCommand())
-                    {
-                        command.Connection = connection;
-                        command.CommandText = @"
-create table Person(
-    Id int identity not null,
-    FavoriteDate datetime,
-    FavoriteDateTimeOffset datetimeoffset,
-    FavoriteLetter nchar(1),
-    FavoriteNumber int,
-    FirstName nvarchar(50),
-    LastName nvarchar(50),
-    Rating decimal(5,2) null
-)";
-
-                        command.ExecuteNonQuery();
-                    }
-                }
-
-                Database = new Database(localDb.ConnectionString, DatabaseType.SqlServer2008);
-
-                Database.InsertBulk(people);
+                Fixture = fixture;
             }
 
-            [TableName("Person")]
-            [PrimaryKey(nameof(Id))]
-            public class Person
-            {
-                public int Id { get; set; }
-                public DateTime FavoriteDate { get; set; }
-                public DateTimeOffset FavoriteDateTimeOffset { get; set; }
-                public char FavoriteLetter { get; set; }
-                public int FavoriteNumber { get; set; }
-                public string FirstName { get; set; }
-                public string LastName { get; set; }
-                public decimal? Rating { get; set; }
-            }
-
-            protected readonly IDatabase Database;
-
-            private readonly IEnumerable<Person> people = new List<Person>()
-            {
-                new Person()
-                {
-                    FavoriteDate = DateTime.Parse("2000-01-01"),
-                    FavoriteDateTimeOffset = DateTimeOffset.Parse("2010-01-01"),
-                    FavoriteLetter = 'a',
-                    FavoriteNumber = 5,
-                    FirstName = "John",
-                    LastName = "Doe"
-                },
-                new Person()
-                {
-                    FavoriteDate = DateTime.Parse("2000-01-02"),
-                    FavoriteDateTimeOffset = DateTimeOffset.Parse("2010-01-02"),
-                    FavoriteLetter = 'b',
-                    FavoriteNumber = 10,
-                    FirstName = "Tim",
-                    LastName = "Smith",
-                    Rating = 4.5m
-                },
-            };
-
-            private LocalDb localDb;
-
-            public void Dispose()
-            {
-                localDb.Dispose();
-                Database.Dispose();
-            }
+            protected readonly DatabaseFixture Fixture;
         }
 
         public class ConstantFilters : Filter
         {
+            public ConstantFilters(DatabaseFixture fixture)
+                :base(fixture)
+            { }
+
             [Fact]
             public void Should_filter_when_property_types_match_as_constant_string()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
                     FirstName = "John"
                 });
@@ -111,7 +40,7 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_constant_integer()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
                     FavoriteNumber = 5
                 });
@@ -124,7 +53,7 @@ create table Person(
             [Fact]
             public void Should_filter_multiple_properties()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
                     FirstName = "John",
                     FavoriteNumber = 0
@@ -137,7 +66,7 @@ create table Person(
             [Fact]
             public void Should_not_throw_if_filter_does_not_contain_valid_properties()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
                     DOESNOTEXIST = ""
                 });
@@ -149,7 +78,7 @@ create table Person(
             [Fact]
             public void Should_not_throw_if_filter_constant_type_does_not_match()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
                     FirstName = 1
                 });
@@ -161,10 +90,14 @@ create table Person(
 
         public class EnumerableFilters : Filter
         {
+            public EnumerableFilters(DatabaseFixture fixture)
+                : base(fixture)
+            { }
+
             [Fact]
             public void Should_bypass_filter_when_empty_collection()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
                     FirstName = new string[] { }
                 });
@@ -176,7 +109,7 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_enumerable_string()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
                     FirstName = new[] { "John" }
                 });
@@ -189,7 +122,7 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_enumerable_integer()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
                     FavoriteNumber = new[] { 5 }
                 });
@@ -202,7 +135,7 @@ create table Person(
             [Fact]
             public void Should_be_able_to_handle_nullable_destination_and_primitive_filter()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
                     Rating = new[] { 4.5m }
                 });
@@ -213,7 +146,7 @@ create table Person(
             [Fact]
             public void Should_be_able_to_handle_nullable_destination_and_nullable_primitive_filter_as_collection()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
                     Rating = new decimal?[] { 4.5m }
                 });
@@ -224,7 +157,7 @@ create table Person(
             [Fact]
             public void Should_be_able_to_handle_nullable_destination_and_nullable_primitive_filter()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
                     Rating = new decimal?(4.5m)
                 });
@@ -235,17 +168,9 @@ create table Person(
             [Fact]
             public void Should_be_able_to_handle_nullable_source()
             {
-                var people = Database.Query<Person>().ToList();
-                people.ForEach(x => x.Rating = null);
-
-                foreach (var person in people)
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
-                    Database.Update(person);
-                }
-
-                var @return = Database.Query<Person>().Filter(new
-                {
-                    Rating = new decimal?[] { 4.5m }
+                    DONOTUSE = new string[] { "whatever" }
                 }).ToList();
 
                 Assert.Empty(@return);
@@ -254,14 +179,18 @@ create table Person(
 
         public class RangeFilters : Filter
         {
+            public RangeFilters(DatabaseFixture fixture)
+                : base(fixture)
+            { }
+
             [Theory,
             InlineData("(,5]"),
             InlineData("(-∞,5]")]
             public void Should_filter_open_ended_lower_bound(string value)
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
-                    FavoriteNumber = Range.Range.FromString<int>(value)
+                    FavoriteNumber = Range.FromString<int>(value)
                 });
 
                 Assert.NotNull(@return);
@@ -274,9 +203,9 @@ create table Person(
             InlineData("(5,+∞)")]
             public void Should_filter_open_ended_upper_bound(string value)
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
-                    FavoriteNumber = Range.Range.FromString<int>(value)
+                    FavoriteNumber = Range.FromString<int>(value)
                 });
 
                 Assert.NotNull(@return);
@@ -287,7 +216,7 @@ create table Person(
             [Fact]
             public void Should_filter_for_concrete_range()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
                     FavoriteNumber = new Range<int>()
                     {
@@ -306,9 +235,9 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_byte()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
-                    FavoriteNumber = Range.Range.FromString<byte>("[5,5]")
+                    FavoriteNumber = Range.FromString<byte>("[5,5]")
                 });
 
                 Assert.NotNull(@return);
@@ -319,9 +248,9 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_char()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
-                    FavoriteLetter = Range.Range.FromString<char>("[a,b)")
+                    FavoriteLetter = Range.FromString<char>("[a,b)")
                 });
 
                 Assert.NotNull(@return);
@@ -332,9 +261,9 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_datetime()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
-                    FavoriteDate = Range.Range.FromString<DateTime>("[2000-01-01,2000-01-02)")
+                    FavoriteDate = Range.FromString<DateTime>("[2000-01-01,2000-01-02)")
                 });
 
                 Assert.NotNull(@return);
@@ -345,9 +274,9 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_datetimeoffset()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
-                    FavoriteDateTimeOffset = Range.Range.FromString<DateTimeOffset>("[2010-01-01,2010-01-02)")
+                    FavoriteDateTimeOffset = Range.FromString<DateTimeOffset>("[2010-01-01,2010-01-02)")
                 });
 
                 Assert.NotNull(@return);
@@ -358,9 +287,9 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_decimal()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
-                    FavoriteNumber = Range.Range.FromString<decimal>("[4.5,5]")
+                    FavoriteNumber = Range.FromString<decimal>("[4.5,5]")
                 });
 
                 Assert.NotNull(@return);
@@ -371,9 +300,9 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_double()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
-                    FavoriteNumber = Range.Range.FromString<double>("[4.5,5]")
+                    FavoriteNumber = Range.FromString<double>("[4.5,5]")
                 });
 
                 Assert.NotNull(@return);
@@ -384,9 +313,9 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_float()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
-                    FavoriteNumber = Range.Range.FromString<float>("[4.5,5]")
+                    FavoriteNumber = Range.FromString<float>("[4.5,5]")
                 });
 
                 Assert.NotNull(@return);
@@ -397,9 +326,9 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_int()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
-                    FavoriteNumber = Range.Range.FromString<int>("[5,5]")
+                    FavoriteNumber = Range.FromString<int>("[5,5]")
                 });
 
                 Assert.NotNull(@return);
@@ -410,9 +339,9 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_long()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
-                    FavoriteNumber = Range.Range.FromString<long>("[5,5]")
+                    FavoriteNumber = Range.FromString<long>("[5,5]")
                 });
 
                 Assert.NotNull(@return);
@@ -423,9 +352,9 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_sbyte()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
-                    FavoriteNumber = Range.Range.FromString<sbyte>("[5,5]")
+                    FavoriteNumber = Range.FromString<sbyte>("[5,5]")
                 });
 
                 Assert.NotNull(@return);
@@ -436,9 +365,9 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_short()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
-                    FavoriteNumber = Range.Range.FromString<short>("[5,5]")
+                    FavoriteNumber = Range.FromString<short>("[5,5]")
                 });
 
                 Assert.NotNull(@return);
@@ -449,9 +378,9 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_uint()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
-                    FavoriteNumber = Range.Range.FromString<uint>("[5,5]")
+                    FavoriteNumber = Range.FromString<uint>("[5,5]")
                 });
 
                 Assert.NotNull(@return);
@@ -462,9 +391,9 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_ulong()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
-                    FavoriteNumber = Range.Range.FromString<ulong>("[5,5]")
+                    FavoriteNumber = Range.FromString<ulong>("[5,5]")
                 });
 
                 Assert.NotNull(@return);
@@ -475,9 +404,9 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_ushort()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
-                    FavoriteNumber = Range.Range.FromString<ushort>("[5,5]")
+                    FavoriteNumber = Range.FromString<ushort>("[5,5]")
                 });
 
                 Assert.NotNull(@return);
@@ -488,7 +417,7 @@ create table Person(
             [Fact]
             public void Should_be_able_to_handle_nullable_source()
             {
-                var @return = Database.Query<Person>().Filter(new
+                var @return = Fixture.Database.Query<Person>().Filter(new
                 {
                     Rating = (Range<decimal>)"[4.5,5.0]"
                 });

--- a/tests/Filter.NPoco.Tests/Person.cs
+++ b/tests/Filter.NPoco.Tests/Person.cs
@@ -1,0 +1,25 @@
+﻿using NPoco;
+using System;
+
+namespace Filter.NPoco.Tests
+{
+    [TableName("Person")]
+    [PrimaryKey(nameof(Id))]
+    public class Person
+    {
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Used for any tests of nullable-values.
+        /// </summary>
+        public string DONOTUSE { get; }
+
+        public DateTime FavoriteDate { get; set; }
+        public DateTimeOffset FavoriteDateTimeOffset { get; set; }
+        public char FavoriteLetter { get; set; }
+        public int FavoriteNumber { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public decimal? Rating { get; set; }
+    }
+}

--- a/tests/Filter.NPoco.Tests/Properties/AssemblyInfo.cs
+++ b/tests/Filter.NPoco.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Filter.NPoco.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Filter.NPoco.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("8d5e1963-14e4-4000-b492-bf24eb73c1aa")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/Filter.NPoco.Tests/SqlBuilderExtensionsTests.cs
+++ b/tests/Filter.NPoco.Tests/SqlBuilderExtensionsTests.cs
@@ -1,0 +1,561 @@
+﻿using NPoco;
+using RimDev.Automation.Sql;
+using RimDev.Filter.NPoco;
+using RimDev.Filter.Range.Generic;
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using Xunit;
+
+namespace RimDev.Filter.Tests
+{
+    public class SqlBuilderExtensionsTests
+    {
+        public class Filter : SqlBuilderExtensionsTests, IDisposable
+        {
+            public Filter()
+            {
+                localDb = new LocalDb(version: "v13.0");
+
+                using (var connection = new SqlConnection(localDb.ConnectionString))
+                {
+                    connection.Open();
+
+                    using (var command = new SqlCommand())
+                    {
+                        command.Connection = connection;
+                        command.CommandText = @"
+create table Person(
+    Id int identity not null,
+    FavoriteDate datetime,
+    FavoriteDateTimeOffset datetimeoffset,
+    FavoriteLetter nchar(1),
+    FavoriteNumber int,
+    FirstName nvarchar(50),
+    LastName nvarchar(50),
+    Rating decimal(5,2) null
+)";
+
+                        command.ExecuteNonQuery();
+                    }
+                }
+
+                Database = new Database(localDb.ConnectionString, DatabaseType.SqlServer2008);
+
+                Database.InsertBulk(people);
+            }
+
+            [TableName("Person")]
+            [PrimaryKey(nameof(Id))]
+            public class Person
+            {
+                public int Id { get; set; }
+                public DateTime FavoriteDate { get; set; }
+                public DateTimeOffset FavoriteDateTimeOffset { get; set; }
+                public char FavoriteLetter { get; set; }
+                public int FavoriteNumber { get; set; }
+                public string FirstName { get; set; }
+                public string LastName { get; set; }
+                public decimal? Rating { get; set; }
+            }
+
+            protected readonly IDatabase Database;
+
+            private readonly IEnumerable<Person> people = new List<Person>()
+            {
+                new Person()
+                {
+                    FavoriteDate = DateTime.Parse("2000-01-01"),
+                    FavoriteDateTimeOffset = DateTimeOffset.Parse("2010-01-01"),
+                    FavoriteLetter = 'a',
+                    FavoriteNumber = 5,
+                    FirstName = "John",
+                    LastName = "Doe"
+                },
+                new Person()
+                {
+                    FavoriteDate = DateTime.Parse("2000-01-02"),
+                    FavoriteDateTimeOffset = DateTimeOffset.Parse("2010-01-02"),
+                    FavoriteLetter = 'b',
+                    FavoriteNumber = 10,
+                    FirstName = "Tim",
+                    LastName = "Smith",
+                    Rating = 4.5m
+                },
+            };
+
+            private LocalDb localDb;
+
+            public void Dispose()
+            {
+                localDb.Dispose();
+                Database.Dispose();
+            }
+        }
+
+        public class ConstantFilters : Filter
+        {
+            [Fact]
+            public void Should_filter_when_property_types_match_as_constant_string()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FirstName = "John"
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Single(@return);
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_constant_integer()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FavoriteNumber = 5
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Single(@return);
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_multiple_properties()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FirstName = "John",
+                        FavoriteNumber = 0
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Empty(@return);
+            }
+
+            [Fact]
+            public void Should_not_throw_if_filter_does_not_contain_valid_properties()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        DOESNOTEXIST = ""
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Equal(2, @return.Count());
+            }
+
+            [Fact]
+            public void Should_not_throw_if_filter_constant_type_does_not_match()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FirstName = 1
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Equal(2, @return.Count());
+            }
+        }
+
+        public class EnumerableFilters : Filter
+        {
+            [Fact]
+            public void Should_bypass_filter_when_empty_collection()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FirstName = new string[] { }
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Equal(2, @return.Count());
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_enumerable_string()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FirstName = new[] { "John" }
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Single(@return);
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_enumerable_integer()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FavoriteNumber = new[] { 5 }
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Single(@return);
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_be_able_to_handle_nullable_destination_and_primitive_filter()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        Rating = new[] { 4.5m }
+                    });
+
+                Assert.Single(@return);
+            }
+
+            [Fact]
+            public void Should_be_able_to_handle_nullable_destination_and_nullable_primitive_filter_as_collection()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        Rating = new decimal?[] { 4.5m }
+                    });
+
+                Assert.Single(@return);
+            }
+
+            [Fact]
+            public void Should_be_able_to_handle_nullable_destination_and_nullable_primitive_filter()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        Rating = new decimal?(4.5m)
+                    });
+
+                Assert.Single(@return);
+            }
+
+            [Fact]
+            public void Should_be_able_to_handle_nullable_source()
+            {
+                var people = Database.Query<Person>().ToList();
+                people.ForEach(x => x.Rating = null);
+
+                foreach (var person in people)
+                {
+                    Database.Update(person);
+                }
+
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        Rating = new decimal?[] { 4.5m }
+                    });
+
+                Assert.Empty(@return);
+            }
+        }
+
+        public class RangeFilters : Filter
+        {
+            [Theory,
+            InlineData("(,5]"),
+            InlineData("(-∞,5]")]
+            public void Should_filter_open_ended_lower_bound(string value)
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FavoriteNumber = Range.Range.FromString<int>(value)
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Single(@return);
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Theory,
+            InlineData("(5,]"),
+            InlineData("(5,+∞)")]
+            public void Should_filter_open_ended_upper_bound(string value)
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FavoriteNumber = Range.Range.FromString<int>(value)
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Single(@return);
+                Assert.Equal("Tim", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_for_concrete_range()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FavoriteNumber = new Range<int>()
+                        {
+                            MinValue = 5,
+                            MaxValue = 5,
+                            IsMinInclusive = true,
+                            IsMaxInclusive = true
+                        }
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Single(@return);
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_byte()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FavoriteNumber = Range.Range.FromString<byte>("[5,5]")
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Single(@return);
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_char()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FavoriteLetter = Range.Range.FromString<char>("[a,b)")
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Single(@return);
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_datetime()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FavoriteDate = Range.Range.FromString<DateTime>("[2000-01-01,2000-01-02)")
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Single(@return);
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_datetimeoffset()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FavoriteDateTimeOffset = Range.Range.FromString<DateTimeOffset>("[2010-01-01,2010-01-02)")
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Single(@return);
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_decimal()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FavoriteNumber = Range.Range.FromString<decimal>("[4.5,5]")
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Single(@return);
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_double()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FavoriteNumber = Range.Range.FromString<double>("[4.5,5]")
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Single(@return);
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_float()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FavoriteNumber = Range.Range.FromString<float>("[4.5,5]")
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Single(@return);
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_int()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FavoriteNumber = Range.Range.FromString<int>("[5,5]")
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Single(@return);
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_long()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FavoriteNumber = Range.Range.FromString<long>("[5,5]")
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Single(@return);
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_sbyte()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FavoriteNumber = Range.Range.FromString<sbyte>("[5,5]")
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Single(@return);
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_short()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FavoriteNumber = Range.Range.FromString<short>("[5,5]")
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Single(@return);
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_uint()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FavoriteNumber = Range.Range.FromString<uint>("[5,5]")
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Single(@return);
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_ulong()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FavoriteNumber = Range.Range.FromString<ulong>("[5,5]")
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Single(@return);
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_filter_when_property_types_match_as_range_ushort()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        FavoriteNumber = Range.Range.FromString<ushort>("[5,5]")
+                    });
+
+                Assert.NotNull(@return);
+                Assert.Single(@return);
+                Assert.Equal("John", @return.First().FirstName);
+            }
+
+            [Fact]
+            public void Should_be_able_to_handle_nullable_source()
+            {
+                var @return = Database
+                    .With<Person>("where /**where**/")
+                    .Fetch(new
+                    {
+                        Rating = (Range<decimal>)"[4.5,5.0]"
+                    });
+
+                Assert.Single(@return);
+            }
+        }
+    }
+}

--- a/tests/Filter.NPoco.Tests/SqlBuilderExtensionsTests.cs
+++ b/tests/Filter.NPoco.Tests/SqlBuilderExtensionsTests.cs
@@ -1,105 +1,34 @@
-﻿using NPoco;
-using RimDev.Automation.Sql;
-using RimDev.Filter.NPoco;
+﻿using RimDev.Filter.NPoco;
+using RimDev.Filter.Range;
 using RimDev.Filter.Range.Generic;
 using System;
-using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Linq;
 using Xunit;
 
-namespace RimDev.Filter.Tests
+namespace Filter.NPoco.Tests
 {
     public class SqlBuilderExtensionsTests
     {
-        public class Filter : SqlBuilderExtensionsTests, IDisposable
+        public abstract class Filter : SqlBuilderExtensionsTests, IClassFixture<DatabaseFixture>
         {
-            public Filter()
+            public Filter(DatabaseFixture fixture)
             {
-                localDb = new LocalDb(version: "v13.0");
-
-                using (var connection = new SqlConnection(localDb.ConnectionString))
-                {
-                    connection.Open();
-
-                    using (var command = new SqlCommand())
-                    {
-                        command.Connection = connection;
-                        command.CommandText = @"
-create table Person(
-    Id int identity not null,
-    FavoriteDate datetime,
-    FavoriteDateTimeOffset datetimeoffset,
-    FavoriteLetter nchar(1),
-    FavoriteNumber int,
-    FirstName nvarchar(50),
-    LastName nvarchar(50),
-    Rating decimal(5,2) null
-)";
-
-                        command.ExecuteNonQuery();
-                    }
-                }
-
-                Database = new Database(localDb.ConnectionString, DatabaseType.SqlServer2008);
-
-                Database.InsertBulk(people);
+                Fixture = fixture;
             }
 
-            [TableName("Person")]
-            [PrimaryKey(nameof(Id))]
-            public class Person
-            {
-                public int Id { get; set; }
-                public DateTime FavoriteDate { get; set; }
-                public DateTimeOffset FavoriteDateTimeOffset { get; set; }
-                public char FavoriteLetter { get; set; }
-                public int FavoriteNumber { get; set; }
-                public string FirstName { get; set; }
-                public string LastName { get; set; }
-                public decimal? Rating { get; set; }
-            }
-
-            protected readonly IDatabase Database;
-
-            private readonly IEnumerable<Person> people = new List<Person>()
-            {
-                new Person()
-                {
-                    FavoriteDate = DateTime.Parse("2000-01-01"),
-                    FavoriteDateTimeOffset = DateTimeOffset.Parse("2010-01-01"),
-                    FavoriteLetter = 'a',
-                    FavoriteNumber = 5,
-                    FirstName = "John",
-                    LastName = "Doe"
-                },
-                new Person()
-                {
-                    FavoriteDate = DateTime.Parse("2000-01-02"),
-                    FavoriteDateTimeOffset = DateTimeOffset.Parse("2010-01-02"),
-                    FavoriteLetter = 'b',
-                    FavoriteNumber = 10,
-                    FirstName = "Tim",
-                    LastName = "Smith",
-                    Rating = 4.5m
-                },
-            };
-
-            private LocalDb localDb;
-
-            public void Dispose()
-            {
-                localDb.Dispose();
-                Database.Dispose();
-            }
+            protected readonly DatabaseFixture Fixture;
         }
 
         public class ConstantFilters : Filter
         {
+            public ConstantFilters(DatabaseFixture fixture)
+                : base(fixture)
+            { }
+
             [Fact]
             public void Should_filter_when_property_types_match_as_constant_string()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
@@ -114,7 +43,7 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_constant_integer()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
@@ -129,7 +58,7 @@ create table Person(
             [Fact]
             public void Should_filter_multiple_properties()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
@@ -144,7 +73,7 @@ create table Person(
             [Fact]
             public void Should_not_throw_if_filter_does_not_contain_valid_properties()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
@@ -158,7 +87,7 @@ create table Person(
             [Fact]
             public void Should_not_throw_if_filter_constant_type_does_not_match()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
@@ -172,10 +101,14 @@ create table Person(
 
         public class EnumerableFilters : Filter
         {
+            public EnumerableFilters(DatabaseFixture fixture)
+                : base(fixture)
+            { }
+
             [Fact]
             public void Should_bypass_filter_when_empty_collection()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
@@ -189,7 +122,7 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_enumerable_string()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
@@ -204,7 +137,7 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_enumerable_integer()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
@@ -219,7 +152,7 @@ create table Person(
             [Fact]
             public void Should_be_able_to_handle_nullable_destination_and_primitive_filter()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
@@ -232,7 +165,7 @@ create table Person(
             [Fact]
             public void Should_be_able_to_handle_nullable_destination_and_nullable_primitive_filter_as_collection()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
@@ -245,7 +178,7 @@ create table Person(
             [Fact]
             public void Should_be_able_to_handle_nullable_destination_and_nullable_primitive_filter()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
@@ -258,19 +191,11 @@ create table Person(
             [Fact]
             public void Should_be_able_to_handle_nullable_source()
             {
-                var people = Database.Query<Person>().ToList();
-                people.ForEach(x => x.Rating = null);
-
-                foreach (var person in people)
-                {
-                    Database.Update(person);
-                }
-
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
-                        Rating = new decimal?[] { 4.5m }
+                        DONOTUSE = new string[] { "whatever" }
                     });
 
                 Assert.Empty(@return);
@@ -279,16 +204,20 @@ create table Person(
 
         public class RangeFilters : Filter
         {
+            public RangeFilters(DatabaseFixture fixture)
+                : base(fixture)
+            { }
+
             [Theory,
             InlineData("(,5]"),
             InlineData("(-∞,5]")]
             public void Should_filter_open_ended_lower_bound(string value)
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
-                        FavoriteNumber = Range.Range.FromString<int>(value)
+                        FavoriteNumber = Range.FromString<int>(value)
                     });
 
                 Assert.NotNull(@return);
@@ -301,11 +230,11 @@ create table Person(
             InlineData("(5,+∞)")]
             public void Should_filter_open_ended_upper_bound(string value)
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
-                        FavoriteNumber = Range.Range.FromString<int>(value)
+                        FavoriteNumber = Range.FromString<int>(value)
                     });
 
                 Assert.NotNull(@return);
@@ -316,7 +245,7 @@ create table Person(
             [Fact]
             public void Should_filter_for_concrete_range()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
@@ -337,11 +266,11 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_byte()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
-                        FavoriteNumber = Range.Range.FromString<byte>("[5,5]")
+                        FavoriteNumber = Range.FromString<byte>("[5,5]")
                     });
 
                 Assert.NotNull(@return);
@@ -352,11 +281,11 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_char()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
-                        FavoriteLetter = Range.Range.FromString<char>("[a,b)")
+                        FavoriteLetter = Range.FromString<char>("[a,b)")
                     });
 
                 Assert.NotNull(@return);
@@ -367,11 +296,11 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_datetime()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
-                        FavoriteDate = Range.Range.FromString<DateTime>("[2000-01-01,2000-01-02)")
+                        FavoriteDate = Range.FromString<DateTime>("[2000-01-01,2000-01-02)")
                     });
 
                 Assert.NotNull(@return);
@@ -382,11 +311,11 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_datetimeoffset()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
-                        FavoriteDateTimeOffset = Range.Range.FromString<DateTimeOffset>("[2010-01-01,2010-01-02)")
+                        FavoriteDateTimeOffset = Range.FromString<DateTimeOffset>("[2010-01-01,2010-01-02)")
                     });
 
                 Assert.NotNull(@return);
@@ -397,11 +326,11 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_decimal()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
-                        FavoriteNumber = Range.Range.FromString<decimal>("[4.5,5]")
+                        FavoriteNumber = Range.FromString<decimal>("[4.5,5]")
                     });
 
                 Assert.NotNull(@return);
@@ -412,11 +341,11 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_double()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
-                        FavoriteNumber = Range.Range.FromString<double>("[4.5,5]")
+                        FavoriteNumber = Range.FromString<double>("[4.5,5]")
                     });
 
                 Assert.NotNull(@return);
@@ -427,11 +356,11 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_float()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
-                        FavoriteNumber = Range.Range.FromString<float>("[4.5,5]")
+                        FavoriteNumber = Range.FromString<float>("[4.5,5]")
                     });
 
                 Assert.NotNull(@return);
@@ -442,11 +371,11 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_int()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
-                        FavoriteNumber = Range.Range.FromString<int>("[5,5]")
+                        FavoriteNumber = Range.FromString<int>("[5,5]")
                     });
 
                 Assert.NotNull(@return);
@@ -457,11 +386,11 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_long()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
-                        FavoriteNumber = Range.Range.FromString<long>("[5,5]")
+                        FavoriteNumber = Range.FromString<long>("[5,5]")
                     });
 
                 Assert.NotNull(@return);
@@ -472,11 +401,11 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_sbyte()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
-                        FavoriteNumber = Range.Range.FromString<sbyte>("[5,5]")
+                        FavoriteNumber = Range.FromString<sbyte>("[5,5]")
                     });
 
                 Assert.NotNull(@return);
@@ -487,11 +416,11 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_short()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
-                        FavoriteNumber = Range.Range.FromString<short>("[5,5]")
+                        FavoriteNumber = Range.FromString<short>("[5,5]")
                     });
 
                 Assert.NotNull(@return);
@@ -502,11 +431,11 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_uint()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
-                        FavoriteNumber = Range.Range.FromString<uint>("[5,5]")
+                        FavoriteNumber = Range.FromString<uint>("[5,5]")
                     });
 
                 Assert.NotNull(@return);
@@ -517,11 +446,11 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_ulong()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
-                        FavoriteNumber = Range.Range.FromString<ulong>("[5,5]")
+                        FavoriteNumber = Range.FromString<ulong>("[5,5]")
                     });
 
                 Assert.NotNull(@return);
@@ -532,11 +461,11 @@ create table Person(
             [Fact]
             public void Should_filter_when_property_types_match_as_range_ushort()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {
-                        FavoriteNumber = Range.Range.FromString<ushort>("[5,5]")
+                        FavoriteNumber = Range.FromString<ushort>("[5,5]")
                     });
 
                 Assert.NotNull(@return);
@@ -547,7 +476,7 @@ create table Person(
             [Fact]
             public void Should_be_able_to_handle_nullable_source()
             {
-                var @return = Database
+                var @return = Fixture.Database
                     .With<Person>("where /**where**/")
                     .Fetch(new
                     {

--- a/tests/Filter.NPoco.Tests/packages.config
+++ b/tests/Filter.NPoco.Tests/packages.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NPoco" version="3.9.4" targetFramework="net462" />
+  <package id="RimDev.Automation.Sql" version="0.3.0" targetFramework="net462" />
+  <package id="RimDev.Sandbox" version="0.2.2" targetFramework="net462" />
+  <package id="RimDev.Sandbox.LocalDb" version="0.2.2" targetFramework="net462" />
+  <package id="xunit" version="2.4.0" targetFramework="net462" />
+  <package id="xunit.abstractions" version="2.0.2" targetFramework="net462" />
+  <package id="xunit.analyzers" version="0.10.0" targetFramework="net462" />
+  <package id="xunit.assert" version="2.4.0" targetFramework="net462" />
+  <package id="xunit.core" version="2.4.0" targetFramework="net462" />
+  <package id="xunit.extensibility.core" version="2.4.0" targetFramework="net462" />
+  <package id="xunit.extensibility.execution" version="2.4.0" targetFramework="net462" />
+  <package id="xunit.runner.msbuild" version="2.4.0" targetFramework="net462" developmentDependency="true" />
+  <package id="xunit.runner.visualstudio" version="2.4.0" targetFramework="net462" developmentDependency="true" />
+</packages>


### PR DESCRIPTION
New behavior allows a few different approaches to integrating Filter.
**All apply filters at the DB-layer**.

The first is implemented via IQueryProvider (i.e. `Database.Query<T>().Filter(...)`).
The second applies to SqlBuilder (i.e. `SqlBuilder.Filter(...).AddTemplate("select * from...")`).
The third allows filtering of non-Query constructs. Helper methods exist to create a `FilterBuilder` and fetch results (i.e. `Database.With<Person>("where /**where**/").Fetch(new { FirstName = "John" })`).