### PR TITLE
Upgrade to NPoco 5.3.1

### DIFF
--- a/src/Filter.NPoco/Filter.NPoco.csproj
+++ b/src/Filter.NPoco/Filter.NPoco.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NPoco" Version="3.9.4" />
+    <PackageReference Include="NPoco" Version="5.3.1" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 

--- a/tests/Filter.NPoco.Tests/Filter.NPoco.Tests.csproj
+++ b/tests/Filter.NPoco.Tests/Filter.NPoco.Tests.csproj
@@ -10,7 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NPoco" Version="3.9.4" />
+    <PackageReference Include="NPoco" Version="5.3.1" />
+    <PackageReference Include="NPoco.SqlServer" Version="5.3.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/tests/Filter.NPoco.Tests/Testing/NPocoDatabaseFixture.cs
+++ b/tests/Filter.NPoco.Tests/Testing/NPocoDatabaseFixture.cs
@@ -4,6 +4,7 @@ using System.Data.SqlClient;
 using Filter.Tests.Common.Testing;
 using Filter.Tests.Common.Testing.Configuration;
 using NPoco;
+using NPoco.SqlServer;
 
 namespace Filter.NPoco.Tests.Testing
 {
@@ -97,9 +98,7 @@ create table Person(
 
         public IDatabase GetDatabaseInstance()
         {
-            var connection = CreateSqlConnection();
-            connection.Open();
-            return new Database(connection, DatabaseType.SqlServer2012);
+            return new SqlServerDatabase(ConnectionString);
         }
     }
 }


### PR DESCRIPTION
- The first 0.99 PR introduced a direct dependency on System.Data.SqlClient when it is only actually required by NPoco indirectly.  In .NET Core convention we should only list direct dependencies (not derived dependencies).
- Upgrade to NPoco 5.3.1 to reduce vulnerabilities.

Note: There are [a few minor changes when upgrading from NPoco v3/v4 to v5](https://github.com/schotime/NPoco/wiki/Upgrading-to-V5)