### PR TITLE
Simplify the configuration rules for test runner

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -3,13 +3,13 @@ New-Item -ItemType directory -Path "build" -Force | Out-Null
 # Release whenever a commit is merged to master
 $ENV:UseMasterReleaseStrategy = "true"
 
-# Control which appsettings.ENV.json also gets loaded for running tests
-$ENV:RIMDEVTEST_ENVIRONMENT = "AppVeyor"
-
 # The following variables should be set to true if unit tests need a Docker container created
 $ENV:RIMDEV_CREATE_TEST_DOCKER_ES = "true" # Elasticsearch on 9201/9301
-$ENV:RIMDEV_CREATE_TEST_DOCKER_SQL = "true" # MS SQL on 11433/11434
-$ENV:RIMDEVTESTS__SQL__PASSWORD = "MvKbeUn18mIxc0r" # This password is used for the temporary Docker container
+$ENV:RIMDEV_CREATE_TEST_DOCKER_SQL = "true" # MS SQL on 11434
+
+$ENV:RIMDEVTESTS__ELASTICSEARCH__URI = "http://localhost:9201"
+$ENV:RIMDEVTESTS__SQL__DATASOURCE = "localhost,11434"
+$ENV:RIMDEVTESTS__SQL__PASSWORD = "MvKbeUn18mIxc0r"
 
 # backwards compatibility for existing build-net5.cake file
 $ENV:RIMDEV_TEST_DOCKER_MSSQL_SA_PASSWORD = $ENV:RIMDEVTESTS__SQL__PASSWORD

--- a/tests/Filter.Tests.Common/Testing/Configuration/ConfigurationHelpers.cs
+++ b/tests/Filter.Tests.Common/Testing/Configuration/ConfigurationHelpers.cs
@@ -11,6 +11,13 @@ namespace Filter.Tests.Common.Testing.Configuration
         /// to load over top of the base appsettings.json file settings.</summary>
         public static string GetRimDevTestEnvironmentName()
         {
+            // https://www.appveyor.com/docs/environment-variables/
+            var appVeyorVariable = Environment.GetEnvironmentVariable("APPVEYOR");
+            var isAppVeyor = !string.IsNullOrEmpty(appVeyorVariable) 
+                && bool.TryParse(appVeyorVariable, out var parsedAppVeyorVariable)
+                && parsedAppVeyorVariable;
+            if (isAppVeyor) return "AppVeyor";
+        
             var rimDevTestEnvironment = Environment.GetEnvironmentVariable("RIMDEVTEST_ENVIRONMENT");
             return string.IsNullOrWhiteSpace(rimDevTestEnvironment) 
                 ? Environments.Development 


### PR DESCRIPTION
When running the tests locally, either through the IDE
or using build.cmd/build.sh -- we should default to
using the appsettings.Development.json.

The appsettings.AppVeyor.json should only be applied
if we are running on the AppVeyor build server.