### PR TITLE
Force System.Text.Encodings.Web versions for vulns

### DIFF
--- a/src/Range.Web.Http.AspNetCore/Range.Web.Http.AspNetCore.csproj
+++ b/src/Range.Web.Http.AspNetCore/Range.Web.Http.AspNetCore.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Filter.Tests.Common/Filter.Tests.Common.csproj
+++ b/tests/Filter.Tests.Common/Filter.Tests.Common.csproj
@@ -14,6 +14,7 @@
       <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
       <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
+      <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
System.Text.Encodings.Web 4.5.0 and 5.0.0 are both
vulnerable.  These are brought in as indirect dependencies
of some direct dependencies.  There is no updated version
of those direct dependencies, but you can force dotnet
to use a non-vulnerable version of the indirect dependency.