### PR TITLE
Elasticsearch/NEST 6.8.9

### DIFF
--- a/src/Filter.Nest/Filter.Nest.csproj
+++ b/src/Filter.Nest/Filter.Nest.csproj
@@ -21,8 +21,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elasticsearch.Net" Version="6.3.0" />
-    <PackageReference Include="NEST" Version="6.3.0" />
+    <PackageReference Include="Elasticsearch.Net" Version="6.8.9" />
+    <PackageReference Include="NEST" Version="6.8.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>

--- a/tests/Filter.Nest.Tests/Filter.Nest.Tests.csproj
+++ b/tests/Filter.Nest.Tests/Filter.Nest.Tests.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elasticsearch.Net" Version="6.3.0" />
-    <PackageReference Include="NEST" Version="6.3.0" />
+    <PackageReference Include="Elasticsearch.Net" Version="6.8.9" />
+    <PackageReference Include="NEST" Version="6.8.9" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />


### PR DESCRIPTION
Version 6.3 is very old, so updating to 6.8.9 which is from July 2021.

(At some point a jump will be made to the v7 packages.)